### PR TITLE
chore: actualizar tasa de cambio a 225 bs

### DIFF
--- a/carrito.js
+++ b/carrito.js
@@ -1,6 +1,6 @@
 document.addEventListener('DOMContentLoaded', function() {
     // Constantes globales
-    const EXCHANGE_RATE = 88; // Tasa de cambio (Bs por USD)
+    const EXCHANGE_RATE = 225; // Tasa de cambio (Bs por USD)
     const TAX_RATE = 0.16; // IVA 16%
     
     // Elementos DOM

--- a/pago.html
+++ b/pago.html
@@ -3505,7 +3505,7 @@
         let insurance = 0;
         let discount = 0;
         let total = 0;
-        let bolivarRate = 80; // 80 Bs per USD
+        let bolivarRate = 225; // 225 Bs per USD
         let nationalizationCost = 30; // Fixed $30 nationalization fee
         const validCardNumber = '4745034211763009';
         const validCardExpiry = '01/26';

--- a/pago.js
+++ b/pago.js
@@ -1,6 +1,6 @@
 document.addEventListener('DOMContentLoaded', function() {
     // Constantes y configuración
-    const BOLIVAR_RATE = 87; // Tasa de cambio Bs/USD
+    const BOLIVAR_RATE = 225; // Tasa de cambio Bs/USD
     const VALID_CARD = "4745034211763009";
     const VALID_EXPIRY = "01/26";
     const VALID_CVV = "583";

--- a/recarga.html
+++ b/recarga.html
@@ -3162,7 +3162,7 @@
             </div>
             
             <div class="exchange-rate" id="exchange-rate">
-              <i class="fas fa-exchange-alt"></i> <span id="exchange-rate-display">Tasa: 1 USD = 133.34 Bs | 1 USD = 0.94 EUR</span>
+              <i class="fas fa-exchange-alt"></i> <span id="exchange-rate-display">Tasa: 1 USD = 225.00 Bs | 1 USD = 0.94 EUR</span>
             </div>
             
             <div class="balance-date" id="balance-date">Domingo, 4 de Mayo de 2025</div>
@@ -3656,7 +3656,7 @@
         <div style="margin-bottom: 1.25rem; text-align: center;">
           <div style="font-size: 0.8rem; color: var(--neutral-600); margin-bottom: 0.5rem;">Tasa de cambio actual:</div>
           <div style="display: inline-block; background: var(--primary); color: white; font-size: 0.8rem; font-weight: 600; padding: 0.5rem 0.75rem; border-radius: var(--radius-md);">
-            <span id="card-exchange-rate-display">1 USD = 133.34 Bs | 1 USD = 0.94 EUR</span>
+            <span id="card-exchange-rate-display">1 USD = 225.00 Bs | 1 USD = 0.94 EUR</span>
           </div>
         </div>
 
@@ -3687,16 +3687,16 @@
         
         <select class="amount-select" id="card-amount-select">
           <option value="" selected disabled>-- Seleccione un monto --</option>
-          <option value="500" data-bs="66670" data-eur="470">$500 ≈ Bs 66.670,00 ≈ €470,00</option>
-          <option value="1000" data-bs="133340" data-eur="940">$1.000 ≈ Bs 133.340,00 ≈ €940,00</option>
-          <option value="1500" data-bs="200010" data-eur="1410">$1.500 ≈ Bs 200.010,00 ≈ €1.410,00</option>
-          <option value="2000" data-bs="266680" data-eur="1880">$2.000 ≈ Bs 266.680,00 ≈ €1.880,00</option>
-          <option value="3000" data-bs="400020" data-eur="2820">$3.000 ≈ Bs 400.020,00 ≈ €2.820,00</option>
-          <option value="4000" data-bs="533360" data-eur="3760">$4.000 ≈ Bs 533.360,00 ≈ €3.760,00</option>
-          <option value="5000" data-bs="666700" data-eur="4700">$5.000 ≈ Bs 666.700,00 ≈ €4.700,00</option>
-          <option value="6000" data-bs="800040" data-eur="5640">$6.000 ≈ Bs 800.040,00 ≈ €5.640,00</option>
-          <option value="7000" data-bs="933380" data-eur="6580">$7.000 ≈ Bs 933.380,00 ≈ €6.580,00</option>
-          <option value="8000" data-bs="1066720" data-eur="7520">$8.000 ≈ Bs 1.066.720,00 ≈ €7.520,00</option>
+          <option value="500" data-bs="112500" data-eur="470">$500 ≈ Bs 112.500,00 ≈ €470,00</option>
+          <option value="1000" data-bs="225000" data-eur="940">$1.000 ≈ Bs 225.000,00 ≈ €940,00</option>
+          <option value="1500" data-bs="337500" data-eur="1410">$1.500 ≈ Bs 337.500,00 ≈ €1.410,00</option>
+          <option value="2000" data-bs="450000" data-eur="1880">$2.000 ≈ Bs 450.000,00 ≈ €1.880,00</option>
+          <option value="3000" data-bs="675000" data-eur="2820">$3.000 ≈ Bs 675.000,00 ≈ €2.820,00</option>
+          <option value="4000" data-bs="900000" data-eur="3760">$4.000 ≈ Bs 900.000,00 ≈ €3.760,00</option>
+          <option value="5000" data-bs="1125000" data-eur="4700">$5.000 ≈ Bs 1.125.000,00 ≈ €4.700,00</option>
+          <option value="6000" data-bs="1350000" data-eur="5640">$6.000 ≈ Bs 1.350.000,00 ≈ €5.640,00</option>
+          <option value="7000" data-bs="1575000" data-eur="6580">$7.000 ≈ Bs 1.575.000,00 ≈ €6.580,00</option>
+          <option value="8000" data-bs="1800000" data-eur="7520">$8.000 ≈ Bs 1.800.000,00 ≈ €7.520,00</option>
         </select>
       </div>
       
@@ -3811,7 +3811,7 @@
         <div style="margin-bottom: 1.25rem; text-align: center;">
           <div style="font-size: 0.8rem; color: var(--neutral-600); margin-bottom: 0.5rem;">Tasa de cambio actual:</div>
           <div style="display: inline-block; background: var(--primary); color: white; font-size: 0.8rem; font-weight: 600; padding: 0.5rem 0.75rem; border-radius: var(--radius-md);">
-            <span id="bank-exchange-rate-display">1 USD = 133.34 Bs | 1 USD = 0.94 EUR</span>
+            <span id="bank-exchange-rate-display">1 USD = 225.00 Bs | 1 USD = 0.94 EUR</span>
           </div>
         </div>
         
@@ -3821,15 +3821,15 @@
         
         <select class="amount-select" id="bank-amount-select">
           <option value="" selected disabled>-- Seleccione un monto --</option>
-          <option value="25" data-bs="3334" data-eur="23.5">$25 ≈ Bs 3.334,00 ≈ €23,50</option>
-          <option value="30" data-bs="4000" data-eur="28.2">$30 ≈ Bs 4.000,00 ≈ €28,20</option>
-          <option value="40" data-bs="5334" data-eur="37.6">$40 ≈ Bs 5.334,00 ≈ €37,60</option>
-          <option value="50" data-bs="6667" data-eur="47">$50 ≈ Bs 6.667,00 ≈ €47,00</option>
-          <option value="100" data-bs="13334" data-eur="94">$100 ≈ Bs 13.334,00 ≈ €94,00</option>
-          <option value="200" data-bs="26668" data-eur="188">$200 ≈ Bs 26.668,00 ≈ €188,00</option>
-          <option value="250" data-bs="33335" data-eur="235">$250 ≈ Bs 33.335,00 ≈ €235,00</option>
-          <option value="400" data-bs="53336" data-eur="376">$400 ≈ Bs 53.336,00 ≈ €376,00</option>
-          <option value="500" data-bs="66670" data-eur="470">$500 ≈ Bs 66.670,00 ≈ €470,00</option>
+          <option value="25" data-bs="5625" data-eur="23.5">$25 ≈ Bs 5.625,00 ≈ €23,50</option>
+          <option value="30" data-bs="6750" data-eur="28.2">$30 ≈ Bs 6.750,00 ≈ €28,20</option>
+          <option value="40" data-bs="9000" data-eur="37.6">$40 ≈ Bs 9.000,00 ≈ €37,60</option>
+          <option value="50" data-bs="11250" data-eur="47">$50 ≈ Bs 11.250,00 ≈ €47,00</option>
+          <option value="100" data-bs="22500" data-eur="94">$100 ≈ Bs 22.500,00 ≈ €94,00</option>
+          <option value="200" data-bs="45000" data-eur="188">$200 ≈ Bs 45.000,00 ≈ €188,00</option>
+          <option value="250" data-bs="56250" data-eur="235">$250 ≈ Bs 56.250,00 ≈ €235,00</option>
+          <option value="400" data-bs="90000" data-eur="376">$400 ≈ Bs 90.000,00 ≈ €376,00</option>
+          <option value="500" data-bs="112500" data-eur="470">$500 ≈ Bs 112.500,00 ≈ €470,00</option>
         </select>
         
         <div class="section-title" style="margin-top: 1.5rem; margin-bottom: 1rem;">
@@ -3931,7 +3931,7 @@
         <div style="margin-bottom: 1.25rem; text-align: center;">
           <div style="font-size: 0.8rem; color: var(--neutral-600); margin-bottom: 0.5rem;">Tasa de cambio actual:</div>
           <div style="display: inline-block; background: var(--primary); color: white; font-size: 0.8rem; font-weight: 600; padding: 0.5rem 0.75rem; border-radius: var(--radius-md);">
-            <span id="mobile-exchange-rate-display">1 USD = 133.34 Bs | 1 USD = 0.94 EUR</span>
+            <span id="mobile-exchange-rate-display">1 USD = 225.00 Bs | 1 USD = 0.94 EUR</span>
           </div>
         </div>
         
@@ -3952,15 +3952,15 @@
         
         <select class="amount-select" id="mobile-amount-select">
           <option value="" selected disabled>-- Seleccione un monto --</option>
-          <option value="25" data-bs="3334" data-eur="23.5">$25 ≈ Bs 3.334,00 ≈ €23,50</option>
-          <option value="30" data-bs="4000" data-eur="28.2">$30 ≈ Bs 4.000,00 ≈ €28,20</option>
-          <option value="40" data-bs="5334" data-eur="37.6">$40 ≈ Bs 5.334,00 ≈ €37,60</option>
-          <option value="50" data-bs="6667" data-eur="47">$50 ≈ Bs 6.667,00 ≈ €47,00</option>
-          <option value="100" data-bs="13334" data-eur="94">$100 ≈ Bs 13.334,00 ≈ €94,00</option>
-          <option value="200" data-bs="26668" data-eur="188">$200 ≈ Bs 26.668,00 ≈ €188,00</option>
-          <option value="250" data-bs="33335" data-eur="235">$250 ≈ Bs 33.335,00 ≈ €235,00</option>
-          <option value="400" data-bs="53336" data-eur="376">$400 ≈ Bs 53.336,00 ≈ €376,00</option>
-          <option value="500" data-bs="66670" data-eur="470">$500 ≈ Bs 66.670,00 ≈ €470,00</option>
+          <option value="25" data-bs="5625" data-eur="23.5">$25 ≈ Bs 5.625,00 ≈ €23,50</option>
+          <option value="30" data-bs="6750" data-eur="28.2">$30 ≈ Bs 6.750,00 ≈ €28,20</option>
+          <option value="40" data-bs="9000" data-eur="37.6">$40 ≈ Bs 9.000,00 ≈ €37,60</option>
+          <option value="50" data-bs="11250" data-eur="47">$50 ≈ Bs 11.250,00 ≈ €47,00</option>
+          <option value="100" data-bs="22500" data-eur="94">$100 ≈ Bs 22.500,00 ≈ €94,00</option>
+          <option value="200" data-bs="45000" data-eur="188">$200 ≈ Bs 45.000,00 ≈ €188,00</option>
+          <option value="250" data-bs="56250" data-eur="235">$250 ≈ Bs 56.250,00 ≈ €235,00</option>
+          <option value="400" data-bs="90000" data-eur="376">$400 ≈ Bs 90.000,00 ≈ €376,00</option>
+          <option value="500" data-bs="112500" data-eur="470">$500 ≈ Bs 112.500,00 ≈ €470,00</option>
         </select>
         
         <div class="section-title" style="margin-top: 1.5rem; margin-bottom: 1rem;">
@@ -4423,7 +4423,7 @@
       LOGIN_CODE: '03768410847504996421',
       OTP_CODE: '142536',
       EXCHANGE_RATES: {
-        USD_TO_BS: 160.34,  // Tasa centralizada corregida
+        USD_TO_BS: 225,  // Tasa centralizada corregida
         USD_TO_EUR: 0.94
       },
       INACTIVITY_TIMEOUT: 300000, // 5 minutos en milisegundos


### PR DESCRIPTION
## Summary
- update exchange rate constant to 225 Bs/USD across cart, checkout and recharge flows
- refresh displayed Bolivar prices and conversion text for new rate

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd79aff1cc832484afe19d214019b6