### PR TITLE
Fix order confirmation date

### DIFF
--- a/checkout.js
+++ b/checkout.js
@@ -1,0 +1,12 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const orderDateEl = document.getElementById('order-date');
+  if (orderDateEl) {
+    const now = new Date();
+    const months = ['enero','febrero','marzo','abril','mayo','junio','julio','agosto','septiembre','octubre','noviembre','diciembre'];
+    const day = now.getDate();
+    const monthName = months[now.getMonth()];
+    const year = now.getFullYear();
+    const formatted = `${day} de ${monthName.charAt(0).toUpperCase() + monthName.slice(1)}, ${year}`;
+    orderDateEl.textContent = formatted;
+  }
+});

--- a/pago.html
+++ b/pago.html
@@ -4122,6 +4122,16 @@
 
         // Event Listeners
         document.addEventListener('DOMContentLoaded', () => {
+            const orderDateEl = document.getElementById('order-date');
+            if (orderDateEl) {
+                const now = new Date();
+                const months = ['enero','febrero','marzo','abril','mayo','junio','julio','agosto','septiembre','octubre','noviembre','diciembre'];
+                const day = now.getDate();
+                const monthName = months[now.getMonth()];
+                const year = now.getFullYear();
+                orderDateEl.textContent = `${day} de ${monthName.charAt(0).toUpperCase() + monthName.slice(1)}, ${year}`;
+            }
+
             // Hide preloader
             setTimeout(() => {
                 preloader.classList.remove('active');

--- a/pagos.html
+++ b/pagos.html
@@ -3691,6 +3691,15 @@
     <script>
         // Inicializar el script cuando el DOM esté cargado
         document.addEventListener('DOMContentLoaded', function() {
+            const orderDateEl = document.getElementById('order-date');
+            if (orderDateEl) {
+                const now = new Date();
+                const day = String(now.getDate()).padStart(2, '0');
+                const month = String(now.getMonth() + 1).padStart(2, '0');
+                const year = now.getFullYear();
+                orderDateEl.textContent = `${day}/${month}/${year}`;
+            }
+
             // Elementos de la interfaz
             const checkoutSteps = document.querySelectorAll('.checkout-step');
             const checkoutSections = document.querySelectorAll('.checkout-section');

--- a/pagos1.html
+++ b/pagos1.html
@@ -3691,6 +3691,15 @@
     <script>
         // Inicializar el script cuando el DOM esté cargado
         document.addEventListener('DOMContentLoaded', function() {
+            const orderDateEl = document.getElementById('order-date');
+            if (orderDateEl) {
+                const now = new Date();
+                const day = String(now.getDate()).padStart(2, '0');
+                const month = String(now.getMonth() + 1).padStart(2, '0');
+                const year = now.getFullYear();
+                orderDateEl.textContent = `${day}/${month}/${year}`;
+            }
+
             // Elementos de la interfaz
             const checkoutSteps = document.querySelectorAll('.checkout-step');
             const checkoutSections = document.querySelectorAll('.checkout-section');


### PR DESCRIPTION
## Summary
- Display current date on order confirmation pages instead of hard-coded value
- Ensure order summaries and details use dynamic date formatting

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/latinstore/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68bda493901c8324ab5aa15db7690c50