### PR TITLE
Improve mobile responsiveness of tracking page

### DIFF
--- a/30966019.html
+++ b/30966019.html
@@ -2,7 +2,7 @@
 <html lang="es">
 <head>
 <meta charset="utf-8"/>
-<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"/>
 <title>Tracking en Vivo — LatinPhone • LP-X9D8NVWE</title>
 <meta name="color-scheme" content="light">
 <style>
@@ -29,10 +29,13 @@
       radial-gradient(1000px 500px at 120% 10%, #18224a 0%, transparent 60%),
       var(--bg);
     color: var(--ink);
-    font: 15px/1.5 "Inter", ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
+    font-family: "Inter", ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
+    font-size: clamp(14px, 1.6vw, 16px);
+    line-height: 1.5;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
   }
+  img, svg, canvas, video { max-width: 100%; height: auto; }
   .wrap { max-width: 1100px; margin: 24px auto; padding: 0 16px; }
 
   /* Animación de entrada */
@@ -192,6 +195,11 @@
     header { position: static; }
     .map { height: 200px; }
     .id { justify-content: flex-start; }
+  }
+  @media (max-width: 600px) {
+    .row { flex-direction: column; align-items: flex-start; }
+    .cta { flex-direction: column; width: 100%; }
+    .cta .btn, .cta button { width: 100%; }
   }
 </style>
 </head>


### PR DESCRIPTION
## Summary
- Disable zoom and fit to screen with updated meta viewport
- Add responsive font sizing and scalable media elements
- Stack rows and call-to-action buttons on small screens

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bdeac7f96c8324ab67db68ad8d15fc