### PR TITLE
Improve mobile responsiveness for LatinPhone pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -697,14 +697,36 @@
                 flex-direction: column;
                 gap: 30px;
             }
-            
+
             .products-table {
                 font-size: 0.9rem;
+                display: block;
+                overflow-x: auto;
+                white-space: nowrap;
             }
             
-            .products-table th:nth-child(3), 
+            .products-table th:nth-child(3),
             .products-table td:nth-child(3) {
                 display: none;
+            }
+        }
+
+        @media (max-width: 480px) {
+            body {
+                font-size: 14px;
+            }
+
+            .logo h1 {
+                font-size: 1.2rem;
+            }
+
+            .products-table {
+                font-size: 0.8rem;
+            }
+
+            .products-table th,
+            .products-table td {
+                padding: 8px 10px;
             }
         }
     </style>

--- a/styles.css
+++ b/styles.css
@@ -1252,3 +1252,13 @@ footer::before {
         font-size: 3.5rem;
     }
 }
+
+@media (max-width: 480px) {
+    html {
+        font-size: 47.5%;
+    }
+
+    .nav-icons {
+        gap: 1.5rem;
+    }
+}


### PR DESCRIPTION
## Summary
- Make product tables scrollable on small screens
- Add extra mobile breakpoint to reduce font sizes and spacing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bee59aa5d08324b07e55fc7d7190c9