### PR TITLE
Use wizard-style flow for pagos and reduce size

### DIFF
--- a/pagos.css
+++ b/pagos.css
@@ -48,7 +48,7 @@
 
         html {
             scroll-behavior: smooth;
-            font-size: 62.5%;
+            font-size: 50%;
             scroll-padding-top: var(--header-height);
             height: 100%;
         }
@@ -78,6 +78,18 @@
             margin: 0 auto;
             padding: 3rem 2rem 5rem;
             width: 100%;
+        }
+
+        .wizard-step {
+            display: none;
+        }
+
+        .wizard-step.active {
+            display: block;
+        }
+
+        .back-btn {
+            margin-bottom: 2rem;
         }
 
         /* Estilos para la cabecera de la página de pago */

--- a/pagos.html
+++ b/pagos.html
@@ -76,8 +76,9 @@
                     </div>
                 </div>
 
-                <h2 class="section-title"><i class="fas fa-globe-americas"></i> Selecciona tu país</h2>
-                <div class="country-grid">
+                <div id="step-country" class="wizard-step active">
+                    <h2 class="section-title"><i class="fas fa-globe-americas"></i> Selecciona tu país</h2>
+                    <div class="country-grid">
                     <div class="country-card" data-country="argentina">
                         <div class="country-flag">🇦🇷</div>
                         <div class="country-name">Argentina</div>
@@ -146,12 +147,17 @@
                         <div class="country-flag">🇻🇪</div>
                         <div class="country-name">Venezuela</div>
                     </div>
+                    </div>
                 </div>
 
                 <div class="product-selection" style="margin-top: 6rem; display: none;">
-                    <h2 class="section-title"><i class="fas fa-list"></i> Selecciona la categoría</h2>
-                    
-                    <div class="category-grid">
+                    <div id="step-category" class="wizard-step">
+                        <button class="btn btn-secondary back-btn" id="back-to-country" style="display:none;">
+                            <i class="fas fa-arrow-left btn-icon"></i>Volver
+                        </button>
+                        <h2 class="section-title"><i class="fas fa-list"></i> Selecciona la categoría</h2>
+
+                        <div class="category-grid">
                         <div class="category-card" data-category="smartphones">
                             <div class="category-icon"><i class="fas fa-mobile-alt"></i></div>
                             <div class="category-info">
@@ -188,72 +194,79 @@
                                 <div class="category-name">Videojuegos</div>
                             </div>
                         </div>
+                        </div>
                     </div>
 
-                    <div class="brand-selection" style="margin-top: 6rem; display: none;">
+                    <div class="brand-selection wizard-step" id="step-brand" style="margin-top: 6rem; display: none;">
+                        <button class="btn btn-secondary back-btn" id="back-to-category">
+                            <i class="fas fa-arrow-left btn-icon"></i>Volver
+                        </button>
                         <h2 class="section-title"><i class="fas fa-building"></i> Selecciona la marca</h2>
-                        
+
                         <div class="brand-grid" id="brand-grid">
                             <!-- Las marcas se cargarán dinámicamente según la categoría seleccionada -->
                         </div>
                     </div>
 
-                    <div class="product-list" style="margin-top: 6rem; display: none;">
+                    <div class="product-step wizard-step" id="step-product" style="margin-top: 6rem; display: none;">
+                        <button class="btn btn-secondary back-btn" id="back-to-brand">
+                            <i class="fas fa-arrow-left btn-icon"></i>Volver
+                        </button>
                         <h2 class="section-title"><i class="fas fa-mobile-alt"></i> Selecciona el producto</h2>
-                        
+
                         <div class="product-grid" id="product-grid">
                             <!-- Los productos se cargarán dinámicamente según la marca seleccionada -->
                         </div>
-                    </div>
 
-                    <div class="cart-section" style="margin-top: 6rem; display: none;">
-                        <h2 class="section-title"><i class="fas fa-shopping-cart"></i> Tu carrito</h2>
+                        <div class="cart-section" style="margin-top: 6rem; display: none;">
+                            <h2 class="section-title"><i class="fas fa-shopping-cart"></i> Tu carrito</h2>
 
-                        <div class="checkout-grid">
-                            <div class="cart-items" id="cart-items">
-                                <div class="cart-empty">
-                                    <i class="fas fa-shopping-cart"></i>
-                                    <p>Tu carrito está vacío</p>
-                                    <p>Selecciona productos para continuar</p>
+                            <div class="checkout-grid">
+                                <div class="cart-items" id="cart-items">
+                                    <div class="cart-empty">
+                                        <i class="fas fa-shopping-cart"></i>
+                                        <p>Tu carrito está vacío</p>
+                                        <p>Selecciona productos para continuar</p>
+                                    </div>
                                 </div>
-                            </div>
 
-                            <div class="order-summary">
-                                <div class="summary-header">
-                                    <i class="fas fa-receipt"></i> Resumen del pedido
-                                </div>
-                                <div class="summary-content">
-                                    <div class="exchange-rate-info">
-                                        Tasa actual: 1 USD = 225 Bs
+                                <div class="order-summary">
+                                    <div class="summary-header">
+                                        <i class="fas fa-receipt"></i> Resumen del pedido
                                     </div>
-                                    <div class="summary-row">
-                                        <span>Subtotal:</span>
-                                        <span id="subtotal">$0.00</span>
-                                    </div>
-                                    <div class="summary-row">
-                                        <span>IVA (16%):</span>
-                                        <span id="tax">$0.00</span>
-                                    </div>
-                                    <div class="summary-row">
-                                        <span>Envío:</span>
-                                        <span id="shipping">$0.00</span>
-                                    </div>
-                                    <div class="summary-row">
-                                        <span>Seguro:</span>
-                                        <span id="insurance">$0.00</span>
-                                    </div>
-                                    <div class="summary-row total">
-                                        <span>Total:</span>
-                                        <div>
-                                            <div id="total">$0.00</div>
-                                            <div class="bs-price" id="total-bs">0.00 Bs</div>
+                                    <div class="summary-content">
+                                        <div class="exchange-rate-info">
+                                            Tasa actual: 1 USD = 225 Bs
                                         </div>
-                                    </div>
+                                        <div class="summary-row">
+                                            <span>Subtotal:</span>
+                                            <span id="subtotal">$0.00</span>
+                                        </div>
+                                        <div class="summary-row">
+                                            <span>IVA (16%):</span>
+                                            <span id="tax">$0.00</span>
+                                        </div>
+                                        <div class="summary-row">
+                                            <span>Envío:</span>
+                                            <span id="shipping">$0.00</span>
+                                        </div>
+                                        <div class="summary-row">
+                                            <span>Seguro:</span>
+                                            <span id="insurance">$0.00</span>
+                                        </div>
+                                        <div class="summary-row total">
+                                            <span>Total:</span>
+                                            <div>
+                                                <div id="total">$0.00</div>
+                                                <div class="bs-price" id="total-bs">0.00 Bs</div>
+                                            </div>
+                                        </div>
 
-                                    <div class="checkout-actions">
-                                        <button class="btn btn-primary btn-block" id="continue-to-shipping" disabled>
-                                            <i class="fas fa-truck btn-icon"></i>Continuar con el envío
-                                        </button>
+                                        <div class="checkout-actions">
+                                            <button class="btn btn-primary btn-block" id="continue-to-shipping" disabled>
+                                                <i class="fas fa-truck btn-icon"></i>Continuar con el envío
+                                            </button>
+                                        </div>
                                     </div>
                                 </div>
                             </div>

--- a/pagos.js
+++ b/pagos.js
@@ -17,9 +17,14 @@
             const categoryCards = document.querySelectorAll('.category-card');
             const brandSelection = document.querySelector('.brand-selection');
             const brandGrid = document.querySelector('#brand-grid');
-            const productList = document.querySelector('.product-list');
             const productGrid = document.querySelector('#product-grid');
             const cartSection = document.querySelector('.cart-section');
+            const stepCountry = document.getElementById('step-country');
+            const stepCategory = document.getElementById('step-category');
+            const stepProduct = document.getElementById('step-product');
+            const backToCountryBtn = document.getElementById('back-to-country');
+            const backToCategoryBtn = document.getElementById('back-to-category');
+            const backToBrandBtn = document.getElementById('back-to-brand');
             const cartItems = document.querySelector('#cart-items');
             const subtotalElement = document.getElementById('subtotal');
             const taxElement = document.getElementById('tax');
@@ -354,12 +359,13 @@
 
                 if (foundProduct) {
                     addToCart({ ...foundProduct, quantity: 1, category: foundCategory, brand: foundBrand });
-                    productSelection.style.display = 'none';
+                    stepCountry.style.display = 'none';
+                    productSelection.style.display = 'block';
+                    stepCategory.style.display = 'none';
+                    brandSelection.style.display = 'none';
+                    stepProduct.style.display = 'block';
                     cartSection.style.display = 'block';
                     showToast('success', 'Producto añadido', `Has añadido ${foundProduct.name} a tu carrito.`);
-                    setTimeout(() => {
-                        cartSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
-                    }, 300);
                 }
 
                 localStorage.removeItem('selectedProduct');
@@ -425,8 +431,14 @@
                 document.querySelector(`.country-card[data-country="${country}"]`).classList.add('selected');
                 selectedCountry = country;
                 
-                // Mostrar la sección de selección de producto
+                // Mostrar la sección de selección de producto (categorías)
+                stepCountry.style.display = 'none';
                 productSelection.style.display = 'block';
+                stepCategory.style.display = 'block';
+                brandSelection.style.display = 'none';
+                stepProduct.style.display = 'none';
+                cartSection.style.display = 'none';
+                backToCountryBtn.style.display = 'inline-flex';
                 
                 // Si el país es Venezuela, ocultar métodos de pago no permitidos
                 if (country === 'venezuela') {
@@ -443,11 +455,6 @@
                 
                 // Notificar al usuario
                 showToast('success', 'País seleccionado', `Has seleccionado ${country}. Ahora elige una categoría de productos.`);
-                
-                // Scroll a la sección de categorías
-                setTimeout(() => {
-                    productSelection.scrollIntoView({ behavior: 'smooth', block: 'start' });
-                }, 300);
 
                 autoAddPreselectedProduct();
             }
@@ -467,18 +474,13 @@
                 renderBrands(category);
                 
                 // Mostrar la sección de selección de marca
+                stepCategory.style.display = 'none';
                 brandSelection.style.display = 'block';
-                
-                // Ocultar secciones siguientes
-                productList.style.display = 'none';
-                
+                stepProduct.style.display = 'none';
+                backToCategoryBtn.style.display = 'inline-flex';
+
                 // Notificar al usuario
                 showToast('info', 'Categoría seleccionada', `Has seleccionado ${category}. Ahora elige una marca.`);
-                
-                // Scroll a la sección de marcas
-                setTimeout(() => {
-                    brandSelection.scrollIntoView({ behavior: 'smooth', block: 'start' });
-                }, 300);
             }
 
             // Función para renderizar las marcas según la categoría
@@ -515,17 +517,14 @@
                         
                         // Renderizar los productos de esta marca
                         renderProducts(category, brand);
-                        
+
                         // Mostrar la lista de productos
-                        productList.style.display = 'block';
-                        
+                        brandSelection.style.display = 'none';
+                        stepProduct.style.display = 'block';
+                        cartSection.style.display = 'none';
+
                         // Notificar al usuario
                         showToast('info', 'Marca seleccionada', `Has seleccionado ${brand}. Ahora elige un producto.`);
-                        
-                        // Scroll a la sección de productos
-                        setTimeout(() => {
-                            productList.scrollIntoView({ behavior: 'smooth', block: 'start' });
-                        }, 300);
                     });
                     
                     brandGrid.appendChild(brandCard);
@@ -619,11 +618,6 @@
                         
                         // Notificar al usuario
                         showToast('success', 'Producto añadido', `Has añadido ${quantity} ${quantity > 1 ? 'unidades' : 'unidad'} de ${addBtn.getAttribute('data-name')} a tu carrito.`);
-                        
-                        // Scroll al carrito
-                        setTimeout(() => {
-                            cartSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
-                        }, 300);
                     });
                     
                     productGrid.appendChild(productCard);
@@ -1294,6 +1288,25 @@
                 card.addEventListener('click', () => {
                     selectCategory(card.getAttribute('data-category'));
                 });
+            });
+
+            // Botones para regresar entre pasos
+            backToCountryBtn.addEventListener('click', () => {
+                stepCategory.style.display = 'none';
+                stepCountry.style.display = 'block';
+                productSelection.style.display = 'none';
+                backToCountryBtn.style.display = 'none';
+            });
+
+            backToCategoryBtn.addEventListener('click', () => {
+                brandSelection.style.display = 'none';
+                stepCategory.style.display = 'block';
+                stepProduct.style.display = 'none';
+            });
+
+            backToBrandBtn.addEventListener('click', () => {
+                stepProduct.style.display = 'none';
+                brandSelection.style.display = 'block';
             });
 
             // 3. Botones de navegación entre pasos


### PR DESCRIPTION
## Summary
- Convert initial payment flow into wizard-style steps for country, category, brand and product selection
- Add navigation buttons and logic to move forward or backward between steps
- Reduce overall UI scale by 20% for better visibility

## Testing
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68beea2b77e08324ba68e63f6dbe31ab