### PR TITLE
Prevent product table text wrapping

### DIFF
--- a/index.html
+++ b/index.html
@@ -345,6 +345,8 @@
         .products-table th, .products-table td {
             padding: 12px 15px;
             border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+            white-space: nowrap;
+            font-size: 0.85rem;
         }
 
         .products-table th {
@@ -707,8 +709,9 @@
             .products-table th,
             .products-table td {
                 padding: 8px 6px;
-                white-space: normal;
-                word-break: break-word;
+                white-space: nowrap;
+                word-break: normal;
+                font-size: 0.8rem;
             }
 
             .buy-btn {


### PR DESCRIPTION
## Summary
- keep product table entries on a single line by disabling wrapping
- reduce table font size for better fit on small screens

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68beeb9905248324b9ea99a13903b605