### PR TITLE
fix: enable mobile receipt upload

### DIFF
--- a/recarga.html
+++ b/recarga.html
@@ -4041,12 +4041,12 @@
           <i class="fas fa-upload"></i> Comprobante de Pago
         </div>
         
-        <div class="receipt-upload" id="mobile-receipt-upload">
+        <label class="receipt-upload" id="mobile-receipt-upload" for="mobile-receipt-file">
           <i class="fas fa-cloud-upload-alt"></i>
           <div class="receipt-upload-title">Subir Comprobante</div>
-          <div class="receipt-upload-subtitle">Haga clic aquí para cargar una captura de su pago móvil<br>Formatos aceptados: JPG, PNG, PDF (máx. 5MB)</div>
-          <input type="file" id="mobile-receipt-file" accept="image/jpeg,image/png,application/pdf" style="display: none;">
-        </div>
+          <div class="receipt-upload-subtitle">Comprobante de tu recarga desde tu <img src="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEhnBzNdjl6bNp-nIdaiHVENczJhwlJNA7ocsyiOObMmzbu8at0dY5yGcZ9cLxLF39qI6gwNfqBxlkTDC0txVULEwQVwGkeEzN0Jq9MRTRagA48mh18UqTlR4WhsXOLAEZugUyhqJHB19xJgnkpe-S5VOWFgzpKFwctv3XP9XhH41vNTvq0ZS-nik58Qhr-O/s320/remeex.png" alt="REMEEX" style="height:1em;vertical-align:middle;"> <br>Formatos aceptados: JPG, PNG, PDF (máx. 5MB)</div>
+        </label>
+        <input type="file" id="mobile-receipt-file" accept="image/jpeg,image/png,application/pdf" style="display: none;">
         
         <div class="receipt-preview" id="mobile-receipt-preview">
           <div class="receipt-preview-container">
@@ -7366,12 +7366,10 @@ function updateVerificationProcessingBanner() {
       
       if (mobileReceiptUpload && mobileReceiptFile) {
         mobileReceiptUpload.addEventListener('click', function() {
-          mobileReceiptFile.click();
-          
           // Reset inactivity timer
           resetInactivityTimer();
         });
-        
+
         mobileReceiptFile.addEventListener('change', function() {
           if (this.files && this.files[0]) {
             const file = this.files[0];


### PR DESCRIPTION
## Summary
- make mobile payment receipt upload clickable
- show Remeex logo in upload instructions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf25b5009483248a1c96b57b894a58