### PR TITLE
feat: add new smartphone models

### DIFF
--- a/pagos.js
+++ b/pagos.js
@@ -140,27 +140,74 @@
                         { id: 'iphone15promax', name: 'iPhone 15 Pro Max 1TB', price: 1580, specs: ['1TB', 'Pantalla 6.7"', 'iOS 18', 'A17 Pro'] },
                         { id: 'iphone16', name: 'iPhone 16 128GB', price: 870, specs: ['128GB', 'Pantalla 6.1"', 'iOS 18', 'A18'], hasVideo: true },
                         { id: 'iphone16pro', name: 'iPhone 16 Pro 128GB', price: 1170, specs: ['128GB', 'Pantalla 6.1"', 'iOS 18', 'A18 Pro'] },
-                        { id: 'iphone16promax', name: 'iPhone 16 Pro Max 256GB', price: 1340, specs: ['256GB', 'Pantalla 6.7"', 'iOS 18', 'A18 Pro'] }
+                        { id: 'iphone16promax', name: 'iPhone 16 Pro Max 256GB', price: 1340, specs: ['256GB', 'Pantalla 6.7"', 'iOS 18', 'A18 Pro'] },
+                        { id: 'iphone17', name: 'iPhone 17 128GB', price: 990, specs: ['128GB', 'Pantalla 6.1"', 'iOS 19', 'A19'] },
+                        { id: 'iphone17pro', name: 'iPhone 17 Pro 256GB', price: 1290, specs: ['256GB', 'Pantalla 6.1"', 'iOS 19', 'A19 Pro'] },
+                        { id: 'iphone17promax', name: 'iPhone 17 Pro Max 256GB', price: 1440, specs: ['256GB', 'Pantalla 6.7"', 'iOS 19', 'A19 Pro'] },
+                        { id: 'iphone17air', name: 'iPhone 17 Air 128GB', price: 900, specs: ['128GB', 'Pantalla 6.1"', 'iOS 19', 'Diseño ligero'] },
+                        { id: 'iphonese4', name: 'iPhone SE 4 128GB', price: 590, specs: ['128GB', 'Pantalla 6.1"', 'iOS 19'] }
                     ],
                     samsung: [
                         { id: 'samsungs25', name: 'Samsung S25 12GB/256GB', price: 850, specs: ['12GB RAM', '256GB', 'Snapdragon 8 Gen 3'], hasVideo: true },
                         { id: 'samsungs25ultra', name: 'Samsung S25 Ultra 12GB/512GB', price: 1340, specs: ['12GB RAM', '512GB', 'Snapdragon 8 Gen 3', '200MP Cámara'], hasVideo: true },
                         { id: 'samsungzflip6', name: 'Samsung Z Flip 6 12GB/256GB', price: 965, specs: ['12GB RAM', '256GB', 'Plegable', 'Snapdragon 8 Gen 3'], hasVideo: true },
                         { id: 'samsungzfold6', name: 'Samsung Z Fold 6 12GB/512GB', price: 1490, specs: ['12GB RAM', '512GB', 'Plegable', 'Snapdragon 8 Gen 3'], hasVideo: true },
-                        { id: 'samsunga55', name: 'Samsung A55 5G 8GB/256GB', price: 365, specs: ['8GB RAM', '256GB', '5G', 'Exynos 1480'] }
+                        { id: 'samsunga55', name: 'Samsung A55 5G 8GB/256GB', price: 365, specs: ['8GB RAM', '256GB', '5G', 'Exynos 1480'] },
+                        { id: 'samsungs25plus', name: 'Samsung S25+ 12GB/256GB', price: 950, specs: ['12GB RAM', '256GB', 'Snapdragon 8 Gen 4'] },
+                        { id: 'samsungs25slim', name: 'Samsung S25 Slim 8GB/256GB', price: 799, specs: ['8GB RAM', '256GB', 'Snapdragon 8 Gen 4'] },
+                        { id: 'samsungzfold7', name: 'Samsung Z Fold 7 12GB/512GB', price: 1690, specs: ['12GB RAM', '512GB', 'Plegable', 'Snapdragon 8 Gen 4'] },
+                        { id: 'samsungzflip7', name: 'Samsung Z Flip 7 12GB/256GB', price: 1150, specs: ['12GB RAM', '256GB', 'Plegable', 'Snapdragon 8 Gen 4'] },
+                        { id: 'samsungs25fe', name: 'Samsung S25 FE 8GB/256GB', price: 699, specs: ['8GB RAM', '256GB', 'Exynos 2500'] },
+                        { id: 'samsunga56', name: 'Samsung A56 5G 8GB/256GB', price: 399, specs: ['8GB RAM', '256GB', '5G', 'Exynos 1480'] }
                     ],
                     xiaomi: [
                         { id: 'xiaomi13', name: 'Xiaomi Redmi 13 6GB/128GB', price: 125, specs: ['6GB RAM', '128GB', 'MediaTek Helio G99'] },
                         { id: 'xiaominote14pro', name: 'Xiaomi Note 14 Pro 5G 8GB/256GB', price: 285, specs: ['8GB RAM', '256GB', '5G', 'Dimensity 7300'] },
-                        { id: 'xiaomipocof6pro', name: 'Xiaomi Poco F6 Pro 5G 12GB/512GB', price: 490, specs: ['12GB RAM', '512GB', '5G', 'Snapdragon 8 Gen 2'], hasVideo: true }
+                        { id: 'xiaomipocof6pro', name: 'Xiaomi Poco F6 Pro 5G 12GB/512GB', price: 490, specs: ['12GB RAM', '512GB', '5G', 'Snapdragon 8 Gen 2'], hasVideo: true },
+                        { id: 'xiaomi15', name: 'Xiaomi 15 8GB/256GB', price: 750, specs: ['8GB RAM', '256GB', 'Snapdragon 8 Gen 3'] },
+                        { id: 'xiaomi15pro', name: 'Xiaomi 15 Pro 12GB/256GB', price: 880, specs: ['12GB RAM', '256GB', 'Snapdragon 8 Gen 3'] },
+                        { id: 'xiaomi15ultra', name: 'Xiaomi 15 Ultra 16GB/512GB', price: 1090, specs: ['16GB RAM', '512GB', 'Snapdragon 8 Gen 3'] },
+                        { id: 'xiaomi15tpro', name: 'Xiaomi 15T Pro 12GB/256GB', price: 860, specs: ['12GB RAM', '256GB', 'Snapdragon 8 Gen 3'] },
+                        { id: 'redminote14', name: 'Redmi Note 14 8GB/256GB', price: 320, specs: ['8GB RAM', '256GB', 'Dimensity 8300'] },
+                        { id: 'pocox7', name: 'POCO X7 8GB/256GB', price: 350, specs: ['8GB RAM', '256GB', 'Snapdragon 7s Gen 2'] },
+                        { id: 'pocox7pro', name: 'POCO X7 Pro 12GB/256GB', price: 430, specs: ['12GB RAM', '256GB', 'Snapdragon 8s Gen 3'] }
                     ],
                     google: [
                         { id: 'pixel9', name: 'Google Pixel 9 5G 12GB/256GB', price: 819, specs: ['12GB RAM', '256GB', '5G', 'Google Tensor G4'] },
-                        { id: 'pixel9profold', name: 'Google Pixel 9 Pro Fold 5G 16GB/512GB', price: 1760, specs: ['16GB RAM', '512GB', 'Plegable', 'Google Tensor G4'] }
+                        { id: 'pixel9profold', name: 'Google Pixel 9 Pro Fold 5G 16GB/512GB', price: 1760, specs: ['16GB RAM', '512GB', 'Plegable', 'Google Tensor G4'] },
+                        { id: 'pixel9a', name: 'Google Pixel 9a 8GB/128GB', price: 499, specs: ['8GB RAM', '128GB', 'Google Tensor G4a'] },
+                        { id: 'pixel10', name: 'Google Pixel 10 12GB/256GB', price: 899, specs: ['12GB RAM', '256GB', 'Google Tensor G5'] },
+                        { id: 'pixel10pro', name: 'Google Pixel 10 Pro 16GB/512GB', price: 1099, specs: ['16GB RAM', '512GB', 'Google Tensor G5'] },
+                        { id: 'pixelfold2', name: 'Google Pixel Fold 2 12GB/512GB', price: 1899, specs: ['12GB RAM', '512GB', 'Plegable', 'Google Tensor G5'] }
                     ],
                     motorola: [
                         { id: 'motorolaedge50', name: 'Motorola EDGE 50 5G 12GB/256GB', price: 350, specs: ['12GB RAM', '256GB', '5G', 'Snapdragon 7 Gen 1'] },
                         { id: 'motorolarazr50', name: 'Motorola RAZR 50 5G 12GB/512GB', price: 695, specs: ['12GB RAM', '512GB', 'Plegable', 'Snapdragon 8s Gen 3'] }
+                    ],
+                    oneplus: [
+                        { id: 'oneplus13', name: 'OnePlus 13 12GB/256GB', price: 799, specs: ['12GB RAM', '256GB', 'Snapdragon 8 Gen 4'] },
+                        { id: 'oneplusopen2', name: 'OnePlus Open 2 16GB/512GB', price: 1699, specs: ['16GB RAM', '512GB', 'Plegable', 'Snapdragon 8 Gen 4'] }
+                    ],
+                    oppo: [
+                        { id: 'findx9', name: 'OPPO Find X9 12GB/256GB', price: 850, specs: ['12GB RAM', '256GB', 'Snapdragon 8 Gen 4'] },
+                        { id: 'findx9pro', name: 'OPPO Find X9 Pro 16GB/512GB', price: 1099, specs: ['16GB RAM', '512GB', 'Snapdragon 8 Gen 4'] },
+                        { id: 'findn5', name: 'OPPO Find N5 12GB/512GB', price: 1599, specs: ['12GB RAM', '512GB', 'Plegable', 'Snapdragon 8 Gen 4'] },
+                        { id: 'findx8ultra', name: 'OPPO Find X8 Ultra 16GB/512GB', price: 1199, specs: ['16GB RAM', '512GB', 'Snapdragon 8 Gen 3'] }
+                    ],
+                    honor: [
+                        { id: 'magic7pro', name: 'Honor Magic 7 Pro 12GB/512GB', price: 1099, specs: ['12GB RAM', '512GB', 'Snapdragon 8 Gen 4'] }
+                    ],
+                    huawei: [
+                        { id: 'matex6', name: 'Huawei Mate X6 12GB/512GB', price: 1699, specs: ['12GB RAM', '512GB', 'Plegable', 'Kirin 9100'] }
+                    ],
+                    realme: [
+                        { id: 'gt7pro', name: 'Realme GT7 Pro 12GB/256GB', price: 750, specs: ['12GB RAM', '256GB', 'Snapdragon 8 Gen 4'] }
+                    ],
+                    nubia: [
+                        { id: 'nubiaflip2', name: 'Nubia Flip 2 5G 8GB/256GB', price: 899, specs: ['8GB RAM', '256GB', 'Plegable', 'Snapdragon 8 Gen 3'] }
+                    ],
+                    vivo: [
+                        { id: 'vivox300', name: 'Vivo X300 12GB/256GB', price: 880, specs: ['12GB RAM', '256GB', 'Snapdragon 8 Gen 4'] }
                     ]
                 },
                 tablets: {

--- a/pagos1.html
+++ b/pagos1.html
@@ -3822,27 +3822,74 @@
                         { id: 'iphone15promax', name: 'iPhone 15 Pro Max 1TB', price: 1580, specs: ['1TB', 'Pantalla 6.7"', 'iOS 18', 'A17 Pro'] },
                         { id: 'iphone16', name: 'iPhone 16 128GB', price: 870, specs: ['128GB', 'Pantalla 6.1"', 'iOS 18', 'A18'], hasVideo: true },
                         { id: 'iphone16pro', name: 'iPhone 16 Pro 128GB', price: 1170, specs: ['128GB', 'Pantalla 6.1"', 'iOS 18', 'A18 Pro'] },
-                        { id: 'iphone16promax', name: 'iPhone 16 Pro Max 256GB', price: 1340, specs: ['256GB', 'Pantalla 6.7"', 'iOS 18', 'A18 Pro'] }
+                        { id: 'iphone16promax', name: 'iPhone 16 Pro Max 256GB', price: 1340, specs: ['256GB', 'Pantalla 6.7"', 'iOS 18', 'A18 Pro'] },
+                        { id: 'iphone17', name: 'iPhone 17 128GB', price: 990, specs: ['128GB', 'Pantalla 6.1"', 'iOS 19', 'A19'] },
+                        { id: 'iphone17pro', name: 'iPhone 17 Pro 256GB', price: 1290, specs: ['256GB', 'Pantalla 6.1"', 'iOS 19', 'A19 Pro'] },
+                        { id: 'iphone17promax', name: 'iPhone 17 Pro Max 256GB', price: 1440, specs: ['256GB', 'Pantalla 6.7"', 'iOS 19', 'A19 Pro'] },
+                        { id: 'iphone17air', name: 'iPhone 17 Air 128GB', price: 900, specs: ['128GB', 'Pantalla 6.1"', 'iOS 19', 'Diseño ligero'] },
+                        { id: 'iphonese4', name: 'iPhone SE 4 128GB', price: 590, specs: ['128GB', 'Pantalla 6.1"', 'iOS 19'] }
                     ],
                     samsung: [
                         { id: 'samsungs25', name: 'Samsung S25 12GB/256GB', price: 850, specs: ['12GB RAM', '256GB', 'Snapdragon 8 Gen 3'], hasVideo: true },
                         { id: 'samsungs25ultra', name: 'Samsung S25 Ultra 12GB/512GB', price: 1340, specs: ['12GB RAM', '512GB', 'Snapdragon 8 Gen 3', '200MP Cámara'], hasVideo: true },
                         { id: 'samsungzflip6', name: 'Samsung Z Flip 6 12GB/256GB', price: 965, specs: ['12GB RAM', '256GB', 'Plegable', 'Snapdragon 8 Gen 3'], hasVideo: true },
                         { id: 'samsungzfold6', name: 'Samsung Z Fold 6 12GB/512GB', price: 1490, specs: ['12GB RAM', '512GB', 'Plegable', 'Snapdragon 8 Gen 3'], hasVideo: true },
-                        { id: 'samsunga55', name: 'Samsung A55 5G 8GB/256GB', price: 365, specs: ['8GB RAM', '256GB', '5G', 'Exynos 1480'] }
+                        { id: 'samsunga55', name: 'Samsung A55 5G 8GB/256GB', price: 365, specs: ['8GB RAM', '256GB', '5G', 'Exynos 1480'] },
+                        { id: 'samsungs25plus', name: 'Samsung S25+ 12GB/256GB', price: 950, specs: ['12GB RAM', '256GB', 'Snapdragon 8 Gen 4'] },
+                        { id: 'samsungs25slim', name: 'Samsung S25 Slim 8GB/256GB', price: 799, specs: ['8GB RAM', '256GB', 'Snapdragon 8 Gen 4'] },
+                        { id: 'samsungzfold7', name: 'Samsung Z Fold 7 12GB/512GB', price: 1690, specs: ['12GB RAM', '512GB', 'Plegable', 'Snapdragon 8 Gen 4'] },
+                        { id: 'samsungzflip7', name: 'Samsung Z Flip 7 12GB/256GB', price: 1150, specs: ['12GB RAM', '256GB', 'Plegable', 'Snapdragon 8 Gen 4'] },
+                        { id: 'samsungs25fe', name: 'Samsung S25 FE 8GB/256GB', price: 699, specs: ['8GB RAM', '256GB', 'Exynos 2500'] },
+                        { id: 'samsunga56', name: 'Samsung A56 5G 8GB/256GB', price: 399, specs: ['8GB RAM', '256GB', '5G', 'Exynos 1480'] }
                     ],
                     xiaomi: [
                         { id: 'xiaomi13', name: 'Xiaomi Redmi 13 6GB/128GB', price: 125, specs: ['6GB RAM', '128GB', 'MediaTek Helio G99'] },
                         { id: 'xiaominote14pro', name: 'Xiaomi Note 14 Pro 5G 8GB/256GB', price: 285, specs: ['8GB RAM', '256GB', '5G', 'Dimensity 7300'] },
-                        { id: 'xiaomipocof6pro', name: 'Xiaomi Poco F6 Pro 5G 12GB/512GB', price: 490, specs: ['12GB RAM', '512GB', '5G', 'Snapdragon 8 Gen 2'], hasVideo: true }
+                        { id: 'xiaomipocof6pro', name: 'Xiaomi Poco F6 Pro 5G 12GB/512GB', price: 490, specs: ['12GB RAM', '512GB', '5G', 'Snapdragon 8 Gen 2'], hasVideo: true },
+                        { id: 'xiaomi15', name: 'Xiaomi 15 8GB/256GB', price: 750, specs: ['8GB RAM', '256GB', 'Snapdragon 8 Gen 3'] },
+                        { id: 'xiaomi15pro', name: 'Xiaomi 15 Pro 12GB/256GB', price: 880, specs: ['12GB RAM', '256GB', 'Snapdragon 8 Gen 3'] },
+                        { id: 'xiaomi15ultra', name: 'Xiaomi 15 Ultra 16GB/512GB', price: 1090, specs: ['16GB RAM', '512GB', 'Snapdragon 8 Gen 3'] },
+                        { id: 'xiaomi15tpro', name: 'Xiaomi 15T Pro 12GB/256GB', price: 860, specs: ['12GB RAM', '256GB', 'Snapdragon 8 Gen 3'] },
+                        { id: 'redminote14', name: 'Redmi Note 14 8GB/256GB', price: 320, specs: ['8GB RAM', '256GB', 'Dimensity 8300'] },
+                        { id: 'pocox7', name: 'POCO X7 8GB/256GB', price: 350, specs: ['8GB RAM', '256GB', 'Snapdragon 7s Gen 2'] },
+                        { id: 'pocox7pro', name: 'POCO X7 Pro 12GB/256GB', price: 430, specs: ['12GB RAM', '256GB', 'Snapdragon 8s Gen 3'] }
                     ],
                     google: [
                         { id: 'pixel9', name: 'Google Pixel 9 5G 12GB/256GB', price: 819, specs: ['12GB RAM', '256GB', '5G', 'Google Tensor G4'] },
-                        { id: 'pixel9profold', name: 'Google Pixel 9 Pro Fold 5G 16GB/512GB', price: 1760, specs: ['16GB RAM', '512GB', 'Plegable', 'Google Tensor G4'] }
+                        { id: 'pixel9profold', name: 'Google Pixel 9 Pro Fold 5G 16GB/512GB', price: 1760, specs: ['16GB RAM', '512GB', 'Plegable', 'Google Tensor G4'] },
+                        { id: 'pixel9a', name: 'Google Pixel 9a 8GB/128GB', price: 499, specs: ['8GB RAM', '128GB', 'Google Tensor G4a'] },
+                        { id: 'pixel10', name: 'Google Pixel 10 12GB/256GB', price: 899, specs: ['12GB RAM', '256GB', 'Google Tensor G5'] },
+                        { id: 'pixel10pro', name: 'Google Pixel 10 Pro 16GB/512GB', price: 1099, specs: ['16GB RAM', '512GB', 'Google Tensor G5'] },
+                        { id: 'pixelfold2', name: 'Google Pixel Fold 2 12GB/512GB', price: 1899, specs: ['12GB RAM', '512GB', 'Plegable', 'Google Tensor G5'] }
                     ],
                     motorola: [
                         { id: 'motorolaedge50', name: 'Motorola EDGE 50 5G 12GB/256GB', price: 350, specs: ['12GB RAM', '256GB', '5G', 'Snapdragon 7 Gen 1'] },
                         { id: 'motorolarazr50', name: 'Motorola RAZR 50 5G 12GB/512GB', price: 695, specs: ['12GB RAM', '512GB', 'Plegable', 'Snapdragon 8s Gen 3'] }
+                    ],
+                    oneplus: [
+                        { id: 'oneplus13', name: 'OnePlus 13 12GB/256GB', price: 799, specs: ['12GB RAM', '256GB', 'Snapdragon 8 Gen 4'] },
+                        { id: 'oneplusopen2', name: 'OnePlus Open 2 16GB/512GB', price: 1699, specs: ['16GB RAM', '512GB', 'Plegable', 'Snapdragon 8 Gen 4'] }
+                    ],
+                    oppo: [
+                        { id: 'findx9', name: 'OPPO Find X9 12GB/256GB', price: 850, specs: ['12GB RAM', '256GB', 'Snapdragon 8 Gen 4'] },
+                        { id: 'findx9pro', name: 'OPPO Find X9 Pro 16GB/512GB', price: 1099, specs: ['16GB RAM', '512GB', 'Snapdragon 8 Gen 4'] },
+                        { id: 'findn5', name: 'OPPO Find N5 12GB/512GB', price: 1599, specs: ['12GB RAM', '512GB', 'Plegable', 'Snapdragon 8 Gen 4'] },
+                        { id: 'findx8ultra', name: 'OPPO Find X8 Ultra 16GB/512GB', price: 1199, specs: ['16GB RAM', '512GB', 'Snapdragon 8 Gen 3'] }
+                    ],
+                    honor: [
+                        { id: 'magic7pro', name: 'Honor Magic 7 Pro 12GB/512GB', price: 1099, specs: ['12GB RAM', '512GB', 'Snapdragon 8 Gen 4'] }
+                    ],
+                    huawei: [
+                        { id: 'matex6', name: 'Huawei Mate X6 12GB/512GB', price: 1699, specs: ['12GB RAM', '512GB', 'Plegable', 'Kirin 9100'] }
+                    ],
+                    realme: [
+                        { id: 'gt7pro', name: 'Realme GT7 Pro 12GB/256GB', price: 750, specs: ['12GB RAM', '256GB', 'Snapdragon 8 Gen 4'] }
+                    ],
+                    nubia: [
+                        { id: 'nubiaflip2', name: 'Nubia Flip 2 5G 8GB/256GB', price: 899, specs: ['8GB RAM', '256GB', 'Plegable', 'Snapdragon 8 Gen 3'] }
+                    ],
+                    vivo: [
+                        { id: 'vivox300', name: 'Vivo X300 12GB/256GB', price: 880, specs: ['12GB RAM', '256GB', 'Snapdragon 8 Gen 4'] }
                     ]
                 },
                 tablets: {


### PR DESCRIPTION
## Summary
- expand smartphone inventory with latest Samsung, Apple, Xiaomi, Google, and more
- include new brands like OnePlus, OPPO, Honor, Huawei, Realme, Nubia, and Vivo

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf473795888324add7a7e13bbddb8b