### PR TITLE
Predeterminar opciones más costosas en pago

### DIFF
--- a/pagos.html
+++ b/pagos.html
@@ -298,7 +298,7 @@
                 <h2 class="section-title" style="margin-top: 6rem;"><i class="fas fa-shipping-fast"></i> Elige tu método de envío</h2>
                 
                 <div class="shipping-options">
-                    <div class="shipping-option" data-shipping="express" data-price="70">
+                    <div class="shipping-option selected" data-shipping="express" data-price="70">
                         <div class="shipping-radio"></div>
                         <div class="shipping-info">
                             <div class="shipping-title">
@@ -366,7 +366,7 @@
 
                 <h2 class="section-title" style="margin-top: 5rem;"><i class="fas fa-shield-alt"></i> Seguro de equipo (opcional)</h2>
                 
-                <div class="insurance-option premium" data-insurance="true" data-price="50">
+                <div class="insurance-option premium selected" data-insurance="true" data-price="50">
                     <div class="shipping-radio"></div>
                     <div class="insurance-info">
                         <div class="insurance-title">
@@ -377,7 +377,7 @@
                     </div>
                     <div class="insurance-price">$50.00</div>
                 </div>
-                <div class="insurance-option selected" data-insurance="false" data-price="0">
+                <div class="insurance-option" data-insurance="false" data-price="0">
                     <div class="shipping-radio"></div>
                     <div class="insurance-info">
                         <div class="insurance-title">

--- a/pagos.js
+++ b/pagos.js
@@ -85,9 +85,9 @@
             let selectedCountry = '';
             let selectedCategory = '';
             let selectedBrand = '';
-            let selectedShipping = { method: 'standard', price: 35 };
+            let selectedShipping = { method: 'express', price: 70 };
             let selectedShippingCompany = 'dhl';
-            let selectedInsurance = { selected: false, price: 0 };
+            let selectedInsurance = { selected: true, price: 50 };
             let selectedGift = null;
             let orderNumber = '';
             let preselectedProductName = localStorage.getItem('selectedProduct');
@@ -1528,10 +1528,16 @@
                 shippingDropdownBtn.querySelector('span').textContent = shippingCompanyOptions[0].querySelector('.shipping-company-text').textContent;
             }
             
-            // Seleccionar por defecto la opción de envío estándar
-            const standardOption = document.querySelector('.shipping-option[data-shipping="standard"]');
-            if (standardOption) {
-                standardOption.classList.add('selected');
+            // Seleccionar por defecto la opción de envío express
+            const expressOption = document.querySelector('.shipping-option[data-shipping="express"]');
+            if (expressOption) {
+                expressOption.classList.add('selected');
+            }
+
+            // Seleccionar por defecto el seguro premium
+            const premiumOption = document.querySelector('.insurance-option.premium');
+            if (premiumOption) {
+                premiumOption.classList.add('selected');
             }
             
             // Deshabilitar botón de continuar al pago hasta aceptar términos


### PR DESCRIPTION
## Summary
- Establece envío **express** como opción predeterminada
- Selecciona el **seguro premium** por defecto para mayor cobertura

## Testing
- `node --check pagos.js`
- `npm test` *(falla: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf4f0d2b3c832487dcdab09ded77bc