### PR TITLE
Añade nuevos modelos de smartphones al catálogo

### DIFF
--- a/index.html
+++ b/index.html
@@ -1029,6 +1029,41 @@
                             <td class="product-price-bs">157.500,00 Bs</td>
                             <td class="buy-cell"><a href="pagos.html" class="buy-btn">Comprar</a></td>
                         </tr>
+                        <tr>
+                            <td class="product-name">iPhone 17</td>
+                            <td>-</td>
+                            <td class="product-price">N/A</td>
+                            <td class="product-price-bs">N/A</td>
+                            <td class="buy-cell"><a href="pagos.html" class="buy-btn">Comprar</a></td>
+                        </tr>
+                        <tr>
+                            <td class="product-name">iPhone 17 Pro</td>
+                            <td>-</td>
+                            <td class="product-price">N/A</td>
+                            <td class="product-price-bs">N/A</td>
+                            <td class="buy-cell"><a href="pagos.html" class="buy-btn">Comprar</a></td>
+                        </tr>
+                        <tr>
+                            <td class="product-name">iPhone 17 Pro Max</td>
+                            <td>-</td>
+                            <td class="product-price">N/A</td>
+                            <td class="product-price-bs">N/A</td>
+                            <td class="buy-cell"><a href="pagos.html" class="buy-btn">Comprar</a></td>
+                        </tr>
+                        <tr>
+                            <td class="product-name">iPhone 17 Slim/Air</td>
+                            <td>-</td>
+                            <td class="product-price">N/A</td>
+                            <td class="product-price-bs">N/A</td>
+                            <td class="buy-cell"><a href="pagos.html" class="buy-btn">Comprar</a></td>
+                        </tr>
+                        <tr>
+                            <td class="product-name">iPhone SE 4</td>
+                            <td>-</td>
+                            <td class="product-price">N/A</td>
+                            <td class="product-price-bs">N/A</td>
+                            <td class="buy-cell"><a href="pagos.html" class="buy-btn">Comprar</a></td>
+                        </tr>
                     </tbody>
                 </table>
                 
@@ -1093,6 +1128,48 @@
                             <td class="product-price-bs">134.100,00 Bs</td>
                             <td class="buy-cell"><a href="pagos.html" class="buy-btn">Comprar</a></td>
                         </tr>
+                        <tr>
+                            <td class="product-name">Samsung S25+</td>
+                            <td>-</td>
+                            <td class="product-price">N/A</td>
+                            <td class="product-price-bs">N/A</td>
+                            <td class="buy-cell"><a href="pagos.html" class="buy-btn">Comprar</a></td>
+                        </tr>
+                        <tr>
+                            <td class="product-name">Samsung S25 Slim</td>
+                            <td>-</td>
+                            <td class="product-price">N/A</td>
+                            <td class="product-price-bs">N/A</td>
+                            <td class="buy-cell"><a href="pagos.html" class="buy-btn">Comprar</a></td>
+                        </tr>
+                        <tr>
+                            <td class="product-name">Samsung Z Fold 7</td>
+                            <td>-</td>
+                            <td class="product-price">N/A</td>
+                            <td class="product-price-bs">N/A</td>
+                            <td class="buy-cell"><a href="pagos.html" class="buy-btn">Comprar</a></td>
+                        </tr>
+                        <tr>
+                            <td class="product-name">Samsung Z Flip 7</td>
+                            <td>-</td>
+                            <td class="product-price">N/A</td>
+                            <td class="product-price-bs">N/A</td>
+                            <td class="buy-cell"><a href="pagos.html" class="buy-btn">Comprar</a></td>
+                        </tr>
+                        <tr>
+                            <td class="product-name">Samsung S25 FE</td>
+                            <td>-</td>
+                            <td class="product-price">N/A</td>
+                            <td class="product-price-bs">N/A</td>
+                            <td class="buy-cell"><a href="pagos.html" class="buy-btn">Comprar</a></td>
+                        </tr>
+                        <tr>
+                            <td class="product-name">Samsung A56</td>
+                            <td>-</td>
+                            <td class="product-price">N/A</td>
+                            <td class="product-price-bs">N/A</td>
+                            <td class="buy-cell"><a href="pagos.html" class="buy-btn">Comprar</a></td>
+                        </tr>
                     </tbody>
                 </table>
                 
@@ -1136,6 +1213,55 @@
                             <td class="product-price-bs">44.100,00 Bs</td>
                             <td class="buy-cell"><a href="pagos.html" class="buy-btn">Comprar</a></td>
                         </tr>
+                        <tr>
+                            <td class="product-name">Xiaomi 15</td>
+                            <td>-</td>
+                            <td class="product-price">N/A</td>
+                            <td class="product-price-bs">N/A</td>
+                            <td class="buy-cell"><a href="pagos.html" class="buy-btn">Comprar</a></td>
+                        </tr>
+                        <tr>
+                            <td class="product-name">Xiaomi 15 Pro</td>
+                            <td>-</td>
+                            <td class="product-price">N/A</td>
+                            <td class="product-price-bs">N/A</td>
+                            <td class="buy-cell"><a href="pagos.html" class="buy-btn">Comprar</a></td>
+                        </tr>
+                        <tr>
+                            <td class="product-name">Xiaomi 15 Ultra</td>
+                            <td>-</td>
+                            <td class="product-price">N/A</td>
+                            <td class="product-price-bs">N/A</td>
+                            <td class="buy-cell"><a href="pagos.html" class="buy-btn">Comprar</a></td>
+                        </tr>
+                        <tr>
+                            <td class="product-name">Xiaomi 15T Pro</td>
+                            <td>-</td>
+                            <td class="product-price">N/A</td>
+                            <td class="product-price-bs">N/A</td>
+                            <td class="buy-cell"><a href="pagos.html" class="buy-btn">Comprar</a></td>
+                        </tr>
+                        <tr>
+                            <td class="product-name">Redmi Note 14</td>
+                            <td>-</td>
+                            <td class="product-price">N/A</td>
+                            <td class="product-price-bs">N/A</td>
+                            <td class="buy-cell"><a href="pagos.html" class="buy-btn">Comprar</a></td>
+                        </tr>
+                        <tr>
+                            <td class="product-name">POCO X7</td>
+                            <td>-</td>
+                            <td class="product-price">N/A</td>
+                            <td class="product-price-bs">N/A</td>
+                            <td class="buy-cell"><a href="pagos.html" class="buy-btn">Comprar</a></td>
+                        </tr>
+                        <tr>
+                            <td class="product-name">POCO X7 Pro</td>
+                            <td>-</td>
+                            <td class="product-price">N/A</td>
+                            <td class="product-price-bs">N/A</td>
+                            <td class="buy-cell"><a href="pagos.html" class="buy-btn">Comprar</a></td>
+                        </tr>
                     </tbody>
                 </table>
                 
@@ -1166,6 +1292,34 @@
                             <td class="product-price-bs">158.400,00 Bs</td>
                             <td class="buy-cell"><a href="pagos.html" class="buy-btn">Comprar</a></td>
                         </tr>
+                        <tr>
+                            <td class="product-name">Google Pixel 9a</td>
+                            <td>-</td>
+                            <td class="product-price">N/A</td>
+                            <td class="product-price-bs">N/A</td>
+                            <td class="buy-cell"><a href="pagos.html" class="buy-btn">Comprar</a></td>
+                        </tr>
+                        <tr>
+                            <td class="product-name">Google Pixel 10</td>
+                            <td>-</td>
+                            <td class="product-price">N/A</td>
+                            <td class="product-price-bs">N/A</td>
+                            <td class="buy-cell"><a href="pagos.html" class="buy-btn">Comprar</a></td>
+                        </tr>
+                        <tr>
+                            <td class="product-name">Google Pixel 10 Pro</td>
+                            <td>-</td>
+                            <td class="product-price">N/A</td>
+                            <td class="product-price-bs">N/A</td>
+                            <td class="buy-cell"><a href="pagos.html" class="buy-btn">Comprar</a></td>
+                        </tr>
+                        <tr>
+                            <td class="product-name">Google Pixel Fold 2</td>
+                            <td>-</td>
+                            <td class="product-price">N/A</td>
+                            <td class="product-price-bs">N/A</td>
+                            <td class="buy-cell"><a href="pagos.html" class="buy-btn">Comprar</a></td>
+                        </tr>
                     </tbody>
                 </table>
                 
@@ -1193,6 +1347,187 @@
                             <td>12GB/512GB</td>
                             <td class="product-price">$860</td>
                             <td class="product-price-bs">77.400,00 Bs</td>
+                            <td class="buy-cell"><a href="pagos.html" class="buy-btn">Comprar</a></td>
+                        </tr>
+                    </tbody>
+                </table>
+                <h4 style="margin-top: 20px; margin-bottom: 10px; color: #fff; border-bottom: 1px solid rgba(255,255,255,0.1); padding-bottom: 5px;">OnePlus</h4>
+                <table class="products-table">
+                    <thead>
+                        <tr>
+                            <th>Producto</th>
+                            <th>Características</th>
+                            <th>Precio USD</th>
+                            <th>Precio Bs</th>
+                            <th></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td class="product-name">OnePlus 13</td>
+                            <td>-</td>
+                            <td class="product-price">N/A</td>
+                            <td class="product-price-bs">N/A</td>
+                            <td class="buy-cell"><a href="pagos.html" class="buy-btn">Comprar</a></td>
+                        </tr>
+                        <tr>
+                            <td class="product-name">OnePlus Open 2</td>
+                            <td>-</td>
+                            <td class="product-price">N/A</td>
+                            <td class="product-price-bs">N/A</td>
+                            <td class="buy-cell"><a href="pagos.html" class="buy-btn">Comprar</a></td>
+                        </tr>
+                    </tbody>
+                </table>
+
+                <h4 style="margin-top: 20px; margin-bottom: 10px; color: #fff; border-bottom: 1px solid rgba(255,255,255,0.1); padding-bottom: 5px;">OPPO</h4>
+                <table class="products-table">
+                    <thead>
+                        <tr>
+                            <th>Producto</th>
+                            <th>Características</th>
+                            <th>Precio USD</th>
+                            <th>Precio Bs</th>
+                            <th></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td class="product-name">OPPO Find X9</td>
+                            <td>-</td>
+                            <td class="product-price">N/A</td>
+                            <td class="product-price-bs">N/A</td>
+                            <td class="buy-cell"><a href="pagos.html" class="buy-btn">Comprar</a></td>
+                        </tr>
+                        <tr>
+                            <td class="product-name">OPPO Find X9 Pro</td>
+                            <td>-</td>
+                            <td class="product-price">N/A</td>
+                            <td class="product-price-bs">N/A</td>
+                            <td class="buy-cell"><a href="pagos.html" class="buy-btn">Comprar</a></td>
+                        </tr>
+                        <tr>
+                            <td class="product-name">OPPO Find N5 (plegable)</td>
+                            <td>-</td>
+                            <td class="product-price">N/A</td>
+                            <td class="product-price-bs">N/A</td>
+                            <td class="buy-cell"><a href="pagos.html" class="buy-btn">Comprar</a></td>
+                        </tr>
+                        <tr>
+                            <td class="product-name">OPPO Find X8 Ultra</td>
+                            <td>-</td>
+                            <td class="product-price">N/A</td>
+                            <td class="product-price-bs">N/A</td>
+                            <td class="buy-cell"><a href="pagos.html" class="buy-btn">Comprar</a></td>
+                        </tr>
+                    </tbody>
+                </table>
+
+                <h4 style="margin-top: 20px; margin-bottom: 10px; color: #fff; border-bottom: 1px solid rgba(255,255,255,0.1); padding-bottom: 5px;">Honor</h4>
+                <table class="products-table">
+                    <thead>
+                        <tr>
+                            <th>Producto</th>
+                            <th>Características</th>
+                            <th>Precio USD</th>
+                            <th>Precio Bs</th>
+                            <th></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td class="product-name">Honor Magic 7 Pro</td>
+                            <td>-</td>
+                            <td class="product-price">N/A</td>
+                            <td class="product-price-bs">N/A</td>
+                            <td class="buy-cell"><a href="pagos.html" class="buy-btn">Comprar</a></td>
+                        </tr>
+                    </tbody>
+                </table>
+
+                <h4 style="margin-top: 20px; margin-bottom: 10px; color: #fff; border-bottom: 1px solid rgba(255,255,255,0.1); padding-bottom: 5px;">Huawei</h4>
+                <table class="products-table">
+                    <thead>
+                        <tr>
+                            <th>Producto</th>
+                            <th>Características</th>
+                            <th>Precio USD</th>
+                            <th>Precio Bs</th>
+                            <th></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td class="product-name">Huawei Mate X6 (plegable)</td>
+                            <td>-</td>
+                            <td class="product-price">N/A</td>
+                            <td class="product-price-bs">N/A</td>
+                            <td class="buy-cell"><a href="pagos.html" class="buy-btn">Comprar</a></td>
+                        </tr>
+                    </tbody>
+                </table>
+
+                <h4 style="margin-top: 20px; margin-bottom: 10px; color: #fff; border-bottom: 1px solid rgba(255,255,255,0.1); padding-bottom: 5px;">Realme</h4>
+                <table class="products-table">
+                    <thead>
+                        <tr>
+                            <th>Producto</th>
+                            <th>Características</th>
+                            <th>Precio USD</th>
+                            <th>Precio Bs</th>
+                            <th></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td class="product-name">Realme GT7 Pro</td>
+                            <td>-</td>
+                            <td class="product-price">N/A</td>
+                            <td class="product-price-bs">N/A</td>
+                            <td class="buy-cell"><a href="pagos.html" class="buy-btn">Comprar</a></td>
+                        </tr>
+                    </tbody>
+                </table>
+
+                <h4 style="margin-top: 20px; margin-bottom: 10px; color: #fff; border-bottom: 1px solid rgba(255,255,255,0.1); padding-bottom: 5px;">Nubia</h4>
+                <table class="products-table">
+                    <thead>
+                        <tr>
+                            <th>Producto</th>
+                            <th>Características</th>
+                            <th>Precio USD</th>
+                            <th>Precio Bs</th>
+                            <th></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td class="product-name">Nubia Flip 2 5G</td>
+                            <td>-</td>
+                            <td class="product-price">N/A</td>
+                            <td class="product-price-bs">N/A</td>
+                            <td class="buy-cell"><a href="pagos.html" class="buy-btn">Comprar</a></td>
+                        </tr>
+                    </tbody>
+                </table>
+
+                <h4 style="margin-top: 20px; margin-bottom: 10px; color: #fff; border-bottom: 1px solid rgba(255,255,255,0.1); padding-bottom: 5px;">Vivo</h4>
+                <table class="products-table">
+                    <thead>
+                        <tr>
+                            <th>Producto</th>
+                            <th>Características</th>
+                            <th>Precio USD</th>
+                            <th>Precio Bs</th>
+                            <th></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td class="product-name">Vivo X300</td>
+                            <td>-</td>
+                            <td class="product-price">N/A</td>
+                            <td class="product-price-bs">N/A</td>
                             <td class="buy-cell"><a href="pagos.html" class="buy-btn">Comprar</a></td>
                         </tr>
                     </tbody>


### PR DESCRIPTION
## Resumen
- Agrega modelos recientes de Apple, Samsung, Xiaomi y Google al listado principal
- Crea secciones para nuevas marcas: OnePlus, OPPO, Honor, Huawei, Realme, Nubia y Vivo

## Testing
- `npm test` *(falla: no se encontró package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf4eb156a88324bbfc767e0e79db6d