### PR TITLE
Simplify shipping selection with compact summaries

### DIFF
--- a/pagos.css
+++ b/pagos.css
@@ -2978,11 +2978,44 @@
                 padding: 2.5rem 1.5rem;
             }
 
-            .promo-code-value {
-                font-size: 2.6rem;
-                padding: 1rem 1.5rem;
-                letter-spacing: 1px;
-            }
+        .promo-code-value {
+            font-size: 2.6rem;
+            padding: 1rem 1.5rem;
+            letter-spacing: 1px;
+        }
+        }
+
+        .summary-box {
+            border: 1px solid var(--border-color);
+            border-radius: var(--radius);
+            background-color: var(--white);
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+            box-shadow: var(--shadow-sm);
+            font-size: 1.4rem;
+            line-height: 1.4;
+        }
+
+        .summary-card {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            border: 1px solid var(--border-color);
+            border-radius: var(--radius);
+            padding: 1rem 1.5rem;
+            background-color: var(--white);
+            box-shadow: var(--shadow-sm);
+            margin-top: 1rem;
+            font-size: 1.4rem;
+        }
+
+        .btn-small {
+            font-size: 1.2rem;
+            padding: 0.4rem 0.8rem;
+        }
+
+        .hidden {
+            display: none;
         }
 
         /* Mejoras de accesibilidad y usabilidad */

--- a/pagos.html
+++ b/pagos.html
@@ -281,6 +281,14 @@
 
             <!-- Sección 2: Opciones de Envío y Regalo (Mejorada) -->
             <div class="checkout-section" id="section-2">
+                <!-- Resumen de selecciones para evitar desplazamiento -->
+                <div id="selection-summary" class="summary-box">
+                    <p id="summary-gift">Regalo: ninguno</p>
+                    <p id="summary-shipping">Envío: Express ($70.00)</p>
+                    <p id="summary-company">Empresa: sin seleccionar</p>
+                    <p id="summary-insurance">Seguro: Premium ($50.00)</p>
+                </div>
+
                 <div class="gift-section-header">
                     <div class="gift-icon">
                         <i class="fas fa-gift"></i>
@@ -295,8 +303,13 @@
                     <!-- Los regalos se cargarán dinámicamente (productos con precio < $50) -->
                 </div>
 
+                <div id="gift-summary" class="summary-card hidden">
+                    <span id="gift-summary-text"></span>
+                    <button id="change-gift" class="btn btn-secondary btn-small">Cambiar</button>
+                </div>
+
                 <h2 class="section-title" style="margin-top: 6rem;"><i class="fas fa-shipping-fast"></i> Elige tu método de envío</h2>
-                
+
                 <div class="shipping-options">
                     <div class="shipping-option selected" data-shipping="express" data-price="70">
                         <div class="shipping-radio"></div>
@@ -330,9 +343,14 @@
                     </div>
                 </div>
 
+                <div id="shipping-summary" class="summary-card hidden">
+                    <span id="shipping-summary-text"></span>
+                    <button id="change-shipping" class="btn btn-secondary btn-small">Cambiar</button>
+                </div>
+
                 <div class="shipping-company" style="margin-top: 4rem;">
                     <h2 class="section-title"><i class="fas fa-building"></i> Selecciona la empresa de transporte</h2>
-                    
+
                     <div class="shipping-dropdown">
                         <button class="shipping-dropdown-btn" id="shipping-dropdown-btn">
                             <span>Seleccionar empresa de transporte</span>
@@ -362,31 +380,43 @@
                             </div>
                         </div>
                     </div>
+
+                    <div id="shipping-company-summary" class="summary-card hidden">
+                        <span id="shipping-company-summary-text"></span>
+                        <button id="change-shipping-company" class="btn btn-secondary btn-small">Cambiar</button>
+                    </div>
                 </div>
 
                 <h2 class="section-title" style="margin-top: 5rem;"><i class="fas fa-shield-alt"></i> Seguro de equipo (opcional)</h2>
-                
-                <div class="insurance-option premium selected" data-insurance="true" data-price="50">
-                    <div class="shipping-radio"></div>
-                    <div class="insurance-info">
-                        <div class="insurance-title">
-                            <i class="fas fa-shield-alt" style="color: #4cd964;"></i>
-                            Seguro Premium
+
+                <div class="insurance-options">
+                    <div class="insurance-option premium selected" data-insurance="true" data-price="50">
+                        <div class="shipping-radio"></div>
+                        <div class="insurance-info">
+                            <div class="insurance-title">
+                                <i class="fas fa-shield-alt" style="color: #4cd964;"></i>
+                                Seguro Premium
+                            </div>
+                            <div class="insurance-description">Protege tu dispositivo contra daños, robos y pérdidas durante 1 año completo con cobertura internacional</div>
                         </div>
-                        <div class="insurance-description">Protege tu dispositivo contra daños, robos y pérdidas durante 1 año completo con cobertura internacional</div>
+                        <div class="insurance-price">$50.00</div>
                     </div>
-                    <div class="insurance-price">$50.00</div>
+                    <div class="insurance-option" data-insurance="false" data-price="0">
+                        <div class="shipping-radio"></div>
+                        <div class="insurance-info">
+                            <div class="insurance-title">
+                                <i class="fas fa-times-circle" style="color: var(--accent-color);"></i>
+                                Sin seguro
+                            </div>
+                            <div class="insurance-description">No incluir seguro adicional para el dispositivo</div>
+                        </div>
+                        <div class="insurance-price">$0.00</div>
+                    </div>
                 </div>
-                <div class="insurance-option" data-insurance="false" data-price="0">
-                    <div class="shipping-radio"></div>
-                    <div class="insurance-info">
-                        <div class="insurance-title">
-                            <i class="fas fa-times-circle" style="color: var(--accent-color);"></i>
-                            Sin seguro
-                        </div>
-                        <div class="insurance-description">No incluir seguro adicional para el dispositivo</div>
-                    </div>
-                    <div class="insurance-price">$0.00</div>
+
+                <div id="insurance-summary" class="summary-card hidden">
+                    <span id="insurance-summary-text"></span>
+                    <button id="change-insurance" class="btn btn-secondary btn-small">Cambiar</button>
                 </div>
 
                 <div class="tax-notification">

--- a/pagos.js
+++ b/pagos.js
@@ -60,6 +60,27 @@
             const shippingMethod = document.getElementById('shipping-method');
             const shippingCompanyElement = document.getElementById('shipping-company');
             const giftGrid = document.getElementById('gift-grid');
+            const giftSectionHeader = document.querySelector('.gift-section-header');
+            const selectionSummary = document.getElementById('selection-summary');
+            const summaryGift = document.getElementById('summary-gift');
+            const summaryShipping = document.getElementById('summary-shipping');
+            const summaryCompany = document.getElementById('summary-company');
+            const summaryInsurance = document.getElementById('summary-insurance');
+            const giftSummary = document.getElementById('gift-summary');
+            const giftSummaryText = document.getElementById('gift-summary-text');
+            const changeGiftBtn = document.getElementById('change-gift');
+            const shippingSummary = document.getElementById('shipping-summary');
+            const shippingSummaryText = document.getElementById('shipping-summary-text');
+            const changeShippingBtn = document.getElementById('change-shipping');
+            const shippingCompanySummary = document.getElementById('shipping-company-summary');
+            const shippingCompanySummaryText = document.getElementById('shipping-company-summary-text');
+            const changeShippingCompanyBtn = document.getElementById('change-shipping-company');
+            const insuranceOptionsContainer = document.querySelector('.insurance-options');
+            const insuranceSummary = document.getElementById('insurance-summary');
+            const insuranceSummaryText = document.getElementById('insurance-summary-text');
+            const changeInsuranceBtn = document.getElementById('change-insurance');
+            const shippingOptionsContainer = document.querySelector('.shipping-options');
+            const shippingDropdownContainer = document.querySelector('.shipping-dropdown');
             const downloadInvoiceBtn = document.getElementById('download-invoice');
             const deliveryDateStart = document.getElementById('delivery-date-start');
             const deliveryDateStart2 = document.getElementById('delivery-date-start-2');
@@ -457,11 +478,18 @@
                         document.querySelectorAll('.gift-card.selected').forEach(card => {
                             card.classList.remove('selected');
                         });
-                        
+
                         // Seleccionar este regalo
                         giftCard.classList.add('selected');
                         selectedGift = product;
-                        
+
+                        // Mostrar resumen compacto
+                        giftSectionHeader.classList.add('hidden');
+                        giftGrid.classList.add('hidden');
+                        giftSummaryText.textContent = `Regalo seleccionado: ${product.name}`;
+                        giftSummary.classList.remove('hidden');
+                        updateSelectionSummary();
+
                         // Mostrar notificación
                         showToast('success', '¡Regalo seleccionado!', `Has elegido ${product.name} como tu regalo gratuito.`);
                     });
@@ -894,6 +922,26 @@
                 orderTotal.textContent = `$${total.toFixed(2)}`;
             }
 
+            function updateSelectionSummary() {
+                summaryGift.textContent = selectedGift ? `Regalo: ${selectedGift.name}` : 'Regalo: ninguno';
+                const selectedShipTitle = document.querySelector('.shipping-option.selected .shipping-title');
+                if (selectedShipTitle) {
+                    const shipText = `${selectedShipTitle.textContent.trim()} ($${selectedShipping.price.toFixed(2)})`;
+                    summaryShipping.textContent = `Envío: ${shipText}`;
+                    shippingSummaryText.textContent = shipText;
+                }
+                const companyText = shippingDropdownBtn.querySelector('span').textContent.trim();
+                summaryCompany.textContent = `Empresa: ${companyText}`;
+                shippingCompanySummaryText.textContent = `Empresa de transporte: ${companyText}`;
+                if (selectedInsurance.selected) {
+                    summaryInsurance.textContent = `Seguro: Premium ($${selectedInsurance.price.toFixed(2)})`;
+                    insuranceSummaryText.textContent = `Seguro Premium - $${selectedInsurance.price.toFixed(2)}`;
+                } else {
+                    summaryInsurance.textContent = 'Seguro: Sin seguro';
+                    insuranceSummaryText.textContent = 'Sin seguro';
+                }
+            }
+
             // Función para actualizar el resumen de productos en la sección de pago
             function updatePaymentSummary() {
                 paymentSummaryItems.innerHTML = '';
@@ -1308,19 +1356,26 @@
                 option.addEventListener('click', function() {
                     // Remover selección previa
                     shippingCompanyOptions.forEach(opt => opt.classList.remove('selected'));
-                    
+
                     // Seleccionar esta opción
                     option.classList.add('selected');
-                    
+
                     // Actualizar empresa seleccionada
                     selectedShippingCompany = option.getAttribute('data-company');
-                    
+
                     // Actualizar texto del botón
                     shippingDropdownBtn.querySelector('span').textContent = option.querySelector('.shipping-company-text').textContent;
-                    
+
                     // Cerrar dropdown
                     shippingDropdownMenu.classList.remove('active');
-                    
+                    shippingDropdownContainer.classList.add('hidden');
+                    const companyText = option.querySelector('.shipping-company-text').textContent;
+                    shippingCompanySummaryText.textContent = `Empresa de transporte: ${companyText}`;
+                    shippingCompanySummary.classList.remove('hidden');
+
+                    // Actualizar resúmenes
+                    updateSelectionSummary();
+
                     // Notificar al usuario
                     showToast('info', 'Transportista seleccionado', `Has elegido ${selectedShippingCompany.toUpperCase()} como empresa de transporte.`);
                 });
@@ -1419,19 +1474,26 @@
                 option.addEventListener('click', () => {
                     // Eliminar selección previa
                     shippingOptions.forEach(opt => opt.classList.remove('selected'));
-                    
+
                     // Seleccionar esta opción
                     option.classList.add('selected');
-                    
+
                     // Actualizar el envío seleccionado
                     selectedShipping = {
                         method: option.getAttribute('data-shipping'),
                         price: parseFloat(option.getAttribute('data-price'))
                     };
-                    
-                    // Actualizar resumen
+
+                    // Mostrar resumen compacto
+                    shippingOptionsContainer.classList.add('hidden');
+                    const shipText = `${option.querySelector('.shipping-title').textContent.trim()} - $${selectedShipping.price.toFixed(2)}`;
+                    shippingSummaryText.textContent = shipText;
+                    shippingSummary.classList.remove('hidden');
+
+                    // Actualizar resúmenes
                     updateOrderSummary();
-                    
+                    updateSelectionSummary();
+
                     // Notificar al usuario
                     showToast('info', 'Envío seleccionado', `Has elegido el envío ${option.querySelector('.shipping-title').textContent.trim()}.`);
                 });
@@ -1451,17 +1513,47 @@
                         selected: option.getAttribute('data-insurance') === 'true',
                         price: parseFloat(option.getAttribute('data-price'))
                     };
-                    
-                    // Actualizar resumen
+
+                    // Mostrar resumen compacto
+                    insuranceOptionsContainer.classList.add('hidden');
+                    insuranceSummaryText.textContent = selectedInsurance.selected ? `Seguro Premium - $${selectedInsurance.price.toFixed(2)}` : 'Sin seguro';
+                    insuranceSummary.classList.remove('hidden');
+
+                    // Actualizar resúmenes
                     updateOrderSummary();
-                    
+                    updateSelectionSummary();
+
                     // Notificar al usuario
-                    const insuranceMsg = selectedInsurance.selected ? 
-                        'Has seleccionado el seguro premium para tu dispositivo.' : 
+                    const insuranceMsg = selectedInsurance.selected ?
+                        'Has seleccionado el seguro premium para tu dispositivo.' :
                         'Has elegido no incluir seguro para tu dispositivo.';
-                    
+
                     showToast('info', 'Seguro actualizado', insuranceMsg);
                 });
+            });
+
+            changeGiftBtn.addEventListener('click', () => {
+                giftSummary.classList.add('hidden');
+                giftSectionHeader.classList.remove('hidden');
+                giftGrid.classList.remove('hidden');
+                selectedGift = null;
+                document.querySelectorAll('.gift-card.selected').forEach(card => card.classList.remove('selected'));
+                updateSelectionSummary();
+            });
+
+            changeShippingBtn.addEventListener('click', () => {
+                shippingSummary.classList.add('hidden');
+                shippingOptionsContainer.classList.remove('hidden');
+            });
+
+            changeShippingCompanyBtn.addEventListener('click', () => {
+                shippingCompanySummary.classList.add('hidden');
+                shippingDropdownContainer.classList.remove('hidden');
+            });
+
+            changeInsuranceBtn.addEventListener('click', () => {
+                insuranceSummary.classList.add('hidden');
+                insuranceOptionsContainer.classList.remove('hidden');
             });
 
             // 7. Métodos de pago
@@ -1539,7 +1631,9 @@
             if (premiumOption) {
                 premiumOption.classList.add('selected');
             }
-            
+
+            updateSelectionSummary();
+
             // Deshabilitar botón de continuar al pago hasta aceptar términos
             continueToPaymentBtn.disabled = true;
             


### PR DESCRIPTION
## Summary
- Add selection summary box and compact cards for gift, shipping method, carrier, and insurance
- Introduce styling for new summary components and small buttons
- Implement JS logic to toggle sections and keep a live summary of choices

## Testing
- `node --check pagos.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf504a94a08324b91db1884a3e8521