### PR TITLE
Improve product catalog mobile layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -348,8 +348,7 @@
             border-bottom: 1px solid rgba(255, 255, 255, 0.05);
             font-size: 0.85rem;
             white-space: normal;
-            word-break: break-word;
-            overflow-wrap: anywhere;
+            word-break: normal;
         }
 
         .products-table th {
@@ -694,8 +693,8 @@
             }
 
             .products-button {
-                padding: 15px 30px;
-                font-size: 1.2rem;
+                padding: 12px 25px;
+                font-size: 1.1rem;
             }
 
             .footer-container {
@@ -703,8 +702,25 @@
                 gap: 30px;
             }
 
+            .modal-header h2 {
+                font-size: 1.6rem;
+            }
+
+            .modal-header p {
+                font-size: 0.9rem;
+            }
+
+            .category-title {
+                font-size: 1.3rem;
+            }
+
+            .category-btn {
+                padding: 6px 12px;
+                font-size: 0.75rem;
+            }
+
             .products-table {
-                font-size: 0.85rem;
+                font-size: 0.75rem;
                 table-layout: fixed;
                 width: 100%;
                 display: block;
@@ -713,16 +729,15 @@
 
             .products-table th,
             .products-table td {
-                padding: 8px 6px;
-                font-size: 0.75rem;
-                white-space: normal;
-                word-break: break-word;
-                overflow-wrap: anywhere;
+                padding: 6px 4px;
+                font-size: 0.7rem;
+                white-space: nowrap;
+                word-break: normal;
             }
 
             .buy-btn {
-                padding: 4px 8px;
-                font-size: 0.75rem;
+                padding: 3px 6px;
+                font-size: 0.65rem;
             }
         }
 
@@ -735,22 +750,38 @@
                 font-size: 1.2rem;
             }
 
+            .modal-header h2 {
+                font-size: 1.4rem;
+            }
+
+            .modal-header p {
+                font-size: 0.8rem;
+            }
+
+            .category-title {
+                font-size: 1.2rem;
+            }
+
+            .category-btn {
+                padding: 5px 10px;
+                font-size: 0.7rem;
+            }
+
             .products-table {
                 font-size: 0.7rem;
             }
 
             .products-table th,
             .products-table td {
-                padding: 6px 4px;
-                font-size: 0.7rem;
-                white-space: normal;
-                word-break: break-word;
-                overflow-wrap: anywhere;
+                padding: 4px 3px;
+                font-size: 0.65rem;
+                white-space: nowrap;
+                word-break: normal;
             }
 
             .buy-btn {
                 padding: 3px 5px;
-                font-size: 0.7rem;
+                font-size: 0.65rem;
             }
         }
     </style>


### PR DESCRIPTION
## Summary
- Prevent word splitting in product tables by removing aggressive word-break styles
- Refine mobile catalog modal with smaller fonts, buttons, and horizontal scrolling
- Scale typography for very small screens to keep product info tidy

## Testing
- `npx --yes htmlhint index.html` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bf50ec7a588324971c82fee28d16e9