### PR TITLE
Order products by price and reduce card size on payment page

### DIFF
--- a/pagos.css
+++ b/pagos.css
@@ -522,8 +522,8 @@
         .brand-grid,
         .product-grid {
             display: grid;
-            grid-template-columns: repeat(auto-fill, minmax(19rem, 1fr));
-            gap: 2rem;
+            grid-template-columns: repeat(auto-fill, minmax(17rem, 1fr));
+            gap: 1.5rem;
             margin-bottom: 3rem;
         }
 
@@ -646,7 +646,7 @@
         .product-media-container {
             position: relative;
             width: 100%;
-            height: 18rem;
+            height: 15rem;
             background-color: var(--light-gray);
             overflow: hidden;
             display: flex;
@@ -655,7 +655,7 @@
         }
 
         .product-icon {
-            font-size: 7rem;
+            font-size: 5rem;
             color: var(--primary-color);
         }
 
@@ -703,7 +703,7 @@
         }
 
         .product-name {
-            font-size: 1.6rem;
+            font-size: 1.4rem;
             font-weight: 600;
             margin-bottom: 1rem;
             color: var(--secondary-color);

--- a/pagos.js
+++ b/pagos.js
@@ -614,7 +614,10 @@
                 productGrid.innerHTML = '';
                 
                 // Obtener los productos para esta categoría y marca
-                const products = inventory[category][brand];
+                // Ordenar los productos por precio (más caros y nuevos primero)
+                const products = inventory[category][brand]
+                    .slice()
+                    .sort((a, b) => b.price - a.price);
                 
                 if (!products) return;
                 


### PR DESCRIPTION
## Summary
- Display the most expensive and recent products first by sorting inventory in the payment flow
- Shrink product cards and adjust grid layout for a more compact view

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf5347aa308324ba36445dc120c9fd