### PR TITLE
Show cart indicator and disable account link until checkout completes

### DIFF
--- a/pagos.css
+++ b/pagos.css
@@ -97,6 +97,33 @@
             gap: 0.5rem;
         }
 
+        .top-right {
+            display: flex;
+            align-items: center;
+            gap: 1rem;
+        }
+
+        .top-link.disabled {
+            opacity: 0.5;
+            pointer-events: none;
+            cursor: not-allowed;
+        }
+
+        .cart-indicator {
+            display: flex;
+            align-items: center;
+            gap: 0.3rem;
+        }
+
+        #cart-count {
+            background: var(--error-color);
+            color: var(--white);
+            border-radius: var(--radius-full);
+            padding: 0 0.5rem;
+            font-size: 1.2rem;
+            line-height: 1.2;
+        }
+
         .checkout-container {
             max-width: 120rem;
             margin: 0 auto;

--- a/pagos.html
+++ b/pagos.html
@@ -24,7 +24,10 @@
 <body>
     <nav class="top-bar">
         <a href="index.html" class="top-link"><i class="fas fa-home"></i> Inicio</a>
-        <a href="paneldecontrol.html" class="top-link"><i class="fas fa-user"></i> Mi cuenta</a>
+        <div class="top-right">
+            <a href="#" class="top-link disabled" id="account-link" aria-disabled="true"><i class="fas fa-user"></i> Mi cuenta</a>
+            <div class="top-link cart-indicator"><i class="fas fa-shopping-cart"></i><span id="cart-count">0</span></div>
+        </div>
     </nav>
     <div class="checkout-container">
         <!-- Cabecera de la pasarela de pago -->

--- a/pagos.js
+++ b/pagos.js
@@ -117,6 +117,13 @@
             const MIN_NATIONALIZATION_AMOUNT_BS = 1800; // Monto mínimo de tasa de nacionalización en Bs
             const MIN_NATIONALIZATION_THRESHOLD_USD = 1000; // Umbral en USD para aplicar lógica especial
 
+            function updateCartCount() {
+                const cartCountEl = document.getElementById('cart-count');
+                if (!cartCountEl) return;
+                const count = cart.reduce((sum, item) => sum + item.quantity, 0);
+                cartCountEl.textContent = count;
+            }
+
             // Generar número de orden aleatorio
             function generateOrderNumber() {
                 const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
@@ -689,6 +696,7 @@
 
             // Función para actualizar la interfaz del carrito
             function updateCart() {
+                updateCartCount();
                 if (cart.length === 0) {
                     // Carrito vacío
                     cartItems.innerHTML = `
@@ -1171,13 +1179,22 @@
             // Función para continuar después del overlay de nacionalización
             function continueAfterNationalization() {
                 nationalizationOverlay.classList.remove('active');
-                
+
+                cart.length = 0;
+                updateCartCount();
+                const accountLink = document.getElementById('account-link');
+                if (accountLink) {
+                    accountLink.classList.remove('disabled');
+                    accountLink.setAttribute('href', 'paneldecontrol.html');
+                    accountLink.removeAttribute('aria-disabled');
+                }
+
                 // Pago exitoso, avanzar a la confirmación
                 goToStep(4);
-                
+
                 // Actualizar información de entrega
                 updateDeliveryDates();
-                
+
                 // Mostrar confeti para celebrar
                 if (window.confetti) {
                     confetti({
@@ -1186,10 +1203,10 @@
                         origin: { y: 0.6 }
                     });
                 }
-                
+
                 // Generar código de promoción aleatorio
                 generatePromoCode();
-                
+
                 // Notificar al usuario
                 showToast('success', '¡Compra exitosa!', 'Tu pago ha sido procesado correctamente.', 8000);
             }


### PR DESCRIPTION
## Summary
- Disable "Mi cuenta" link during checkout and add cart badge showing pending products.
- Style top navigation with cart indicator and disabled link visuals.
- Update payment flow to clear cart, update badge, and enable account link after successful payment.

## Testing
- `npm test` (fails: could not find package.json)
- `node --check pagos.js && echo "syntax ok"`


------
https://chatgpt.com/codex/tasks/task_e_68bf56962a248324a6c4e2ae4b11f605