### PR TITLE
Mostrar monto y logo SENIAT al aceptar tasa

### DIFF
--- a/pagos.css
+++ b/pagos.css
@@ -1727,6 +1727,7 @@
             position: relative;
             z-index: 1;
             line-height: 1.5;
+            text-align: justify;
         }
 
         .tax-checkbox {
@@ -1751,6 +1752,12 @@
             color: var(--secondary-color);
             cursor: pointer;
             line-height: 1.4;
+            text-align: justify;
+        }
+
+        .seniat-logo {
+            max-width: 15rem;
+            margin-top: 1rem;
         }
 
         /* Payment Methods Section mejorado */

--- a/pagos.html
+++ b/pagos.html
@@ -430,6 +430,10 @@
                         <input type="checkbox" id="accept-tax" required>
                         <label for="accept-tax">Entiendo y acepto que debo pagar la tasa de nacionalización (2%) en moneda local.</label>
                     </div>
+                    <div id="tax-info" style="display: none; text-align: justify;">
+                        <p>El monto aproximado a pagar es <strong><span id="tax-amount-bs"></span> Bs</strong>.</p>
+                        <img src="https://catcgr.com/wp-content/uploads/2024/02/seniat-300x107.png" alt="Logo SENIAT" class="seniat-logo">
+                    </div>
                 </div>
 
                 <div class="checkout-actions" style="margin-top: 5rem; display: flex; justify-content: space-between; flex-wrap: wrap; gap: 1.5rem;">

--- a/pagos.js
+++ b/pagos.js
@@ -43,6 +43,8 @@
             const shippingCompanyOptions = document.querySelectorAll('.shipping-company-option');
             const insuranceOptions = document.querySelectorAll('.insurance-option');
             const acceptTaxCheckbox = document.getElementById('accept-tax');
+            const taxInfo = document.getElementById('tax-info');
+            const taxAmountBs = document.getElementById('tax-amount-bs');
             const paymentOptions = document.querySelectorAll('.payment-option');
             const paymentSummaryItems = document.getElementById('payment-summary-items');
             const paymentSubtotal = document.getElementById('payment-subtotal');
@@ -1574,7 +1576,15 @@
             closeNationalizationBtn.addEventListener('click', continueAfterNationalization);
 
             // 11. Escuchar cambios en el checkbox de aceptación de tasas
-            acceptTaxCheckbox.addEventListener('change', updateContinueToPaymentBtnState);
+            acceptTaxCheckbox.addEventListener('change', function() {
+                if (acceptTaxCheckbox.checked) {
+                    taxAmountBs.textContent = nationalizationFee.textContent;
+                    taxInfo.style.display = 'block';
+                } else {
+                    taxInfo.style.display = 'none';
+                }
+                updateContinueToPaymentBtnState();
+            });
 
             // Manejar eventos de teclas para accesibilidad
             document.addEventListener('keydown', function(e) {


### PR DESCRIPTION
## Summary
- Muestra el monto estimado en bolívares y el logo del SENIAT al aceptar la tasa de nacionalización.
- Justifica el texto informativo de nacionalización y ajusta el estilo del bloque correspondiente.
- Controla la visualización del detalle de la tasa mediante JavaScript.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf587fb7b08324bc457331eb0429be