### PR TITLE
Add PC category with single laptop offer

### DIFF
--- a/index.html
+++ b/index.html
@@ -952,7 +952,7 @@
                 <button class="category-btn" data-category="smartwatches">Smartwatches</button>
                 <button class="category-btn" data-category="audio">Audio</button>
                 <button class="category-btn" data-category="tv">TV y Streaming</button>
-                <button class="category-btn" data-category="laptops">Laptops</button>
+                <button class="category-btn" data-category="pc">PC</button>
                 <button class="category-btn" data-category="gaming">Gaming</button>
                 <button class="category-btn" data-category="accesorios">Accesorios</button>
                 <button class="category-btn" data-category="redes">Redes</button>
@@ -1849,8 +1849,8 @@
                 </table>
             </div>
             
-            <div class="product-category" id="laptops">
-                <h3 class="category-title">Computadoras / Laptops</h3>
+            <div class="product-category" id="pc">
+                <h3 class="category-title">Computadoras / PC</h3>
                 <table class="products-table">
                     <thead>
                         <tr>
@@ -1867,20 +1867,6 @@
                             <td>16GB/1TB 15,6"</td>
                             <td class="product-price">$720</td>
                             <td class="product-price-bs">64.800,00 Bs</td>
-                            <td class="buy-cell"><a href="pagos.html" class="buy-btn">Comprar</a></td>
-                        </tr>
-                        <tr>
-                            <td class="product-name">DELL Intel i7-1265U</td>
-                            <td>16/512GB 14"</td>
-                            <td class="product-price">$724</td>
-                            <td class="product-price-bs">65.160,00 Bs</td>
-                            <td class="buy-cell"><a href="pagos.html" class="buy-btn">Comprar</a></td>
-                        </tr>
-                        <tr>
-                            <td class="product-name">Lenovo R7 7730U</td>
-                            <td>16GB/512GB 15.6"</td>
-                            <td class="product-price">$590</td>
-                            <td class="product-price-bs">53.100,00 Bs</td>
                             <td class="buy-cell"><a href="pagos.html" class="buy-btn">Comprar</a></td>
                         </tr>
                     </tbody>
@@ -2060,7 +2046,7 @@
         <div class="info-cards">
             <div class="info-card">
                 <h3>Nuestra Empresa</h3>
-                <p>Con más de 10 años de experiencia en el mercado, nos hemos consolidado como líderes en la distribución de smartphones, tablets, laptops y accesorios de las mejores marcas.</p>
+                <p>Con más de 10 años de experiencia en el mercado, nos hemos consolidado como líderes en la distribución de smartphones, tablets, PC y accesorios de las mejores marcas.</p>
                 <p>Ofrecemos productos 100% originales con garantía internacional y servicios de envío a todos los países de Latinoamérica.</p>
                 <ul class="info-list">
                     <li>Distribución mayorista y detallista</li>
@@ -2104,7 +2090,7 @@
                     <li><a href="#" class="modal-category-link" data-category="smartwatches">Smartwatches</a></li>
                     <li><a href="#" class="modal-category-link" data-category="audio">Audio</a></li>
                     <li><a href="#" class="modal-category-link" data-category="tv">TV y Streaming</a></li>
-                    <li><a href="#" class="modal-category-link" data-category="laptops">Laptops</a></li>
+                    <li><a href="#" class="modal-category-link" data-category="pc">PC</a></li>
                 </ul>
             </div>
             

--- a/pagos.html
+++ b/pagos.html
@@ -201,6 +201,12 @@
                                 <div class="category-name">Videojuegos</div>
                             </div>
                         </div>
+                        <div class="category-card" data-category="pc">
+                            <div class="category-icon"><i class="fas fa-laptop"></i></div>
+                            <div class="category-info">
+                                <div class="category-name">PC</div>
+                            </div>
+                        </div>
                         </div>
                     </div>
 

--- a/pagos.js
+++ b/pagos.js
@@ -155,7 +155,8 @@
                 'smartwatches': 'fas fa-stopwatch',
                 'accesorios': 'fas fa-headphones',
                 'televisores': 'fas fa-tv',
-                'videojuegos': 'fas fa-gamepad'
+                'videojuegos': 'fas fa-gamepad',
+                'pc': 'fas fa-laptop'
             };
 
             // Logos for specific brands
@@ -171,7 +172,8 @@
                 huawei: 'https://www.logo.wine/a/logo/Huawei/Huawei-Logo.wine.svg',
                 realme: 'https://upload.wikimedia.org/wikipedia/commons/thumb/f/f5/Realme-realme-_logo_box-RGB-01_with_out_back_ground.svg/609px-Realme-realme-_logo_box-RGB-01_with_out_back_ground.svg.png',
                 nubia: 'https://upload.wikimedia.org/wikipedia/commons/thumb/f/f6/Nubia_logo.svg/512px-Nubia_logo.svg.png',
-                vivo: 'https://www.logo.wine/a/logo/Vivo_(technology_company)/Vivo_(technology_company)-Logo.wine.svg'
+                vivo: 'https://www.logo.wine/a/logo/Vivo_(technology_company)/Vivo_(technology_company)-Logo.wine.svg',
+                hp: 'https://1000logos.net/wp-content/uploads/2017/03/HP-Logo-500x281.png'
             };
 
             // Base de datos de productos del inventario proporcionado
@@ -260,7 +262,6 @@
                     apple: [
                         { id: 'ipadair', name: 'iPad Air 11" M2 128GB', price: 650, specs: ['Chip M2', '128GB', 'Pantalla 11"'] },
                         { id: 'ipadpro', name: 'iPad Pro 11" M4 256GB', price: 1030, specs: ['Chip M4', '256GB', 'Pantalla 11"'] },
-                        { id: 'HP I7 1355U', name: 'HP I7 1355U" 16 1TB', price: 800, specs: ['I7 1355U', '1TB', 'Pantalla 15.6 WIN11+OFFICE"'] }
                     ],
                     samsung: [
                         { id: 'samsungtaba9', name: 'Samsung Tab A9 X110 4/64GB', price: 125, specs: ['4GB RAM', '64GB', 'Pantalla 8.7"'] },
@@ -319,6 +320,11 @@
                     microsoft: [
                         { id: 'xboxseriess', name: 'Xbox Series S', price: 360, specs: ['SSD 512GB', 'Hasta 1440p', 'Ray Tracing'] },
                         { id: 'xboxseriesx', name: 'Xbox Series X', price: 599, specs: ['SSD 1TB', '4K a 120fps', 'Ray Tracing'] }
+                    ]
+                },
+                pc: {
+                    hp: [
+                        { id: 'hp1355u', name: 'HP I7 1355U 16GB/1TB', price: 720, specs: ['I7 1355U', '16GB RAM', '1TB SSD', 'Pantalla 15.6"', 'Windows 11 + Office'] }
                     ]
                 }
             };


### PR DESCRIPTION
## Summary
- Add PC category and display the only available HP laptop
- Include PC selection in payment workflow with proper icons and inventory data
- Update site copy to reference PC instead of laptops

## Testing
- `node --check pagos.js`
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf5c803c6083248a4e5a32cc67d7f6