### PR TITLE
Show account access overlay before purchase

### DIFF
--- a/pagos.css
+++ b/pagos.css
@@ -105,7 +105,6 @@
 
         .top-link.disabled {
             opacity: 0.5;
-            pointer-events: none;
             cursor: not-allowed;
         }
 
@@ -2225,6 +2224,34 @@
             gap: 1rem;
             justify-content: center;
             flex-wrap: wrap;
+        }
+
+        /* Overlay de acceso a cuenta */
+        .account-overlay {
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: rgba(0, 0, 0, 0.4);
+            display: none;
+            align-items: center;
+            justify-content: center;
+            z-index: var(--z-overlay);
+        }
+
+        .account-overlay.active {
+            display: flex;
+        }
+
+        .account-modal {
+            background: var(--white);
+            padding: 3rem;
+            border-radius: var(--radius);
+            box-shadow: var(--shadow-lg);
+            text-align: center;
+            max-width: 40rem;
+            width: 90%;
         }
 
         /* Loading Overlay mejorado */

--- a/pagos.html
+++ b/pagos.html
@@ -809,6 +809,15 @@
         </div>
     </div>
 
+    <!-- Overlay de acceso a cuenta -->
+    <div class="account-overlay" id="account-overlay">
+        <div class="account-modal">
+            <h3>Acceso restringido</h3>
+            <p>Debes completar la compra para acceder a tu cuenta y desde allí podrás ver la factura de compra, seguimiento de la orden, cambios, seguros, anulación de pago y servicio de asistencia.</p>
+            <button class="btn btn-primary" id="account-overlay-close">Entendido</button>
+        </div>
+    </div>
+
     <!-- Toast Notifications -->
     <div class="toast-container" id="toast-container">
         <!-- Toast notifications se agregarán aquí dinámicamente -->

--- a/pagos.js
+++ b/pagos.js
@@ -102,6 +102,9 @@
             const addMoreOverlay = document.getElementById('add-more-overlay');
             const addMoreBtn = document.getElementById('add-more-btn');
             const continueCheckoutBtn = document.getElementById('continue-checkout-btn');
+            const accountLink = document.getElementById('account-link');
+            const accountOverlay = document.getElementById('account-overlay');
+            const accountOverlayClose = document.getElementById('account-overlay-close');
 
             // Variables para almacenar el estado del pedido
             const cart = [];
@@ -1209,7 +1212,6 @@
 
                 cart.length = 0;
                 updateCartCount();
-                const accountLink = document.getElementById('account-link');
                 if (accountLink) {
                     accountLink.classList.remove('disabled');
                     accountLink.setAttribute('href', 'paneldecontrol.html');
@@ -1459,6 +1461,29 @@
                 addMoreOverlay.classList.remove('active');
                 continueToShippingBtn.click();
             });
+
+            if (accountLink) {
+                accountLink.addEventListener('click', (e) => {
+                    if (accountLink.classList.contains('disabled')) {
+                        e.preventDefault();
+                        if (accountOverlay) {
+                            accountOverlay.classList.add('active');
+                        }
+                    }
+                });
+            }
+
+            if (accountOverlay && accountOverlayClose) {
+                accountOverlayClose.addEventListener('click', () => {
+                    accountOverlay.classList.remove('active');
+                });
+
+                accountOverlay.addEventListener('click', (e) => {
+                    if (e.target === accountOverlay) {
+                        accountOverlay.classList.remove('active');
+                    }
+                });
+            }
 
             backToProductsBtn.addEventListener('click', () => {
                 goToStep(1);


### PR DESCRIPTION
## Summary
- Add account access overlay and styles
- Show overlay when disabled account link is clicked
- Enable account link after purchase completion

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check pagos.js`

------
https://chatgpt.com/codex/tasks/task_e_68bf5f00d7bc8324b91e8ce5d834c677