### PR TITLE
Add Zelle and PayPal payment flow improvements

### DIFF
--- a/pago.html
+++ b/pago.html
@@ -1485,6 +1485,12 @@
             transition: all 0.3s;
         }
 
+        .payment-method.disabled {
+            opacity: 0.5;
+            cursor: not-allowed;
+            pointer-events: none;
+        }
+
         .payment-method:hover {
             transform: translateY(-3px);
             box-shadow: 0 5px 15px rgba(0, 0, 0, 0.05);
@@ -2836,19 +2842,25 @@
                                             </div>
                                             <div class="payment-method-name">Tarjeta</div>
                                         </div>
+                                        <div class="payment-method" data-payment="zelle">
+                                            <div class="payment-method-icon">
+                                                <i class="fas fa-university"></i>
+                                            </div>
+                                            <div class="payment-method-name">Zelle</div>
+                                        </div>
                                         <div class="payment-method" data-payment="paypal">
                                             <div class="payment-method-icon">
                                                 <i class="fab fa-paypal"></i>
                                             </div>
                                             <div class="payment-method-name">PayPal</div>
                                         </div>
-                                        <div class="payment-method" data-payment="crypto">
+                                        <div class="payment-method disabled" data-payment="crypto">
                                             <div class="payment-method-icon">
                                                 <i class="fab fa-bitcoin"></i>
                                             </div>
                                             <div class="payment-method-name">Crypto</div>
                                         </div>
-                                        <div class="payment-method" data-payment="pago-movil">
+                                        <div class="payment-method disabled" data-payment="pago-movil">
                                             <div class="payment-method-icon">
                                                 <i class="fas fa-money-bill-wave"></i>
                                             </div>
@@ -2924,12 +2936,25 @@
                                         <label class="custom-control-label" for="save-card">Guardar esta tarjeta para compras futuras</label>
                                     </div>
                                 </div>
-                                
+
+                                <!-- Zelle Form -->
+                                <div class="payment-method-form" id="zelle-payment-form">
+                                    <p>Realiza un Zelle a <strong>latinphone@usa.com</strong> por el monto de <strong id="zelle-amount">$0.00</strong>.</p>
+                                    <div class="form-group">
+                                        <label for="zelle-email" class="form-label">Correo desde donde envías</label>
+                                        <input type="email" class="form-control" id="zelle-email" placeholder="tu-correo@example.com" required>
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="zelle-receipt" class="form-label">Adjuntar comprobante</label>
+                                        <input type="file" class="form-control" id="zelle-receipt" accept="image/*,application/pdf">
+                                    </div>
+                                </div>
+
                                 <!-- PayPal Form -->
                                 <div class="payment-method-form" id="paypal-payment-form">
                                     <div class="text-center p-3">
                                         <img src="https://www.paypalobjects.com/webstatic/mktg/logo/pp_cc_mark_111x69.jpg" alt="PayPal" height="60">
-                                        <p class="mt-3">Al hacer clic en "Continuar", serás redirigido a PayPal para completar tu compra de forma segura.</p>
+                                        <p class="mt-3">Haz clic en "Finalizar compra" para coordinar tu pago PayPal vía WhatsApp.</p>
                                     </div>
                                 </div>
                                 
@@ -3570,6 +3595,7 @@
             document.getElementById('tracking-nationalization-bs').textContent = formatBolivares(nationalizationCost);
             document.getElementById('pago-movil-amount').textContent = formatCurrency(total);
             document.getElementById('pago-movil-amount-bs').textContent = formatBolivares(total);
+            document.getElementById('zelle-amount').textContent = formatCurrency(total);
             totalBs.textContent = formatBolivares(total);
             
             // Update nationalization percentage
@@ -4057,6 +4083,15 @@
                     }
                     
                     return true;
+                } else if (paymentType === 'zelle') {
+                    const zelleEmail = document.getElementById('zelle-email').value;
+                    if (!zelleEmail) {
+                        showNotification('Por favor, indica el correo desde donde envías el Zelle.', 'error');
+                        return false;
+                    }
+                    return true;
+                } else if (paymentType === 'paypal') {
+                    return true;
                 } else if (paymentType === 'pago-movil') {
                     // Validate Pago Móvil fields
                     const banco = document.getElementById('banco-emisor').value;
@@ -4171,7 +4206,21 @@
             });
             
             document.getElementById('go-to-step-4').addEventListener('click', () => {
-                if (validateStep(3)) showOTPModal();
+                if (!validateStep(3)) return;
+                const active = document.querySelector('.payment-methods .payment-method.active');
+                const paymentType = active ? active.getAttribute('data-payment') : '';
+                const displayMap = { card: 'Tarjeta de crédito', zelle: 'Zelle', paypal: 'PayPal' };
+                document.getElementById('payment-method-display').textContent = displayMap[paymentType] || '';
+
+                if (paymentType === 'card') {
+                    showOTPModal();
+                } else if (paymentType === 'paypal') {
+                    const message = `Hola, quiero pagar mi compra de ${formatCurrency(total)} via PayPal.`;
+                    window.open(`https://wa.me/18133584564?text=${encodeURIComponent(message)}`, '_blank');
+                    goToStep(4);
+                } else {
+                    goToStep(4);
+                }
             });
             
             // Persistent summary continue button
@@ -4179,7 +4228,20 @@
                 if (currentStep < 4) {
                     if (validateStep(currentStep)) {
                         if (currentStep === 3) {
-                            showOTPModal();
+                            const active = document.querySelector('.payment-methods .payment-method.active');
+                            const paymentType = active ? active.getAttribute('data-payment') : '';
+                            const displayMap = { card: 'Tarjeta de crédito', zelle: 'Zelle', paypal: 'PayPal' };
+                            document.getElementById('payment-method-display').textContent = displayMap[paymentType] || '';
+
+                            if (paymentType === 'card') {
+                                showOTPModal();
+                            } else if (paymentType === 'paypal') {
+                                const message = `Hola, quiero pagar mi compra de ${formatCurrency(total)} via PayPal.`;
+                                window.open(`https://wa.me/18133584564?text=${encodeURIComponent(message)}`, '_blank');
+                                goToStep(4);
+                            } else {
+                                goToStep(4);
+                            }
                         } else {
                             goToStep(currentStep + 1);
                         }


### PR DESCRIPTION
## Summary
- Add Zelle payment option with email and receipt fields
- Route PayPal payments to WhatsApp and disable crypto/pago móvil methods
- Update validation and summary logic for new payment flows

## Testing
- `npx --yes htmlhint pago.html` *(fails: 403 Forbidden - GET https://registry.npmjs.org/htmlhint)*

------
https://chatgpt.com/codex/tasks/task_e_68bf60330f448324b3f7a407ce09710c