### PR TITLE
Fix overlapping catalog titles

### DIFF
--- a/index.html
+++ b/index.html
@@ -335,6 +335,15 @@
             padding-bottom: 10px;
         }
 
+        .brand-title {
+            margin-top: 20px;
+            margin-bottom: 10px;
+            color: #fff;
+            border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+            padding-bottom: 5px;
+            display: block;
+        }
+
         .products-table {
             width: 100%;
             border-collapse: collapse;
@@ -962,7 +971,7 @@
             <div class="product-category active" id="smartphones">
                 <h3 class="category-title">Smartphones</h3>
                 
-                <h4 style="margin-top: 20px; margin-bottom: 10px; color: #fff; border-bottom: 1px solid rgba(255,255,255,0.1); padding-bottom: 5px;">Apple</h4>
+                <h4 class="brand-title">Apple</h4>
                 <table class="products-table">
                     <thead>
                         <tr>
@@ -1096,7 +1105,7 @@
                     </tbody>
                 </table>
                 
-                <h4 style="margin-top: 20px; margin-bottom: 10px; color: #fff; border-bottom: 1px solid rgba(255,255,255,0.1); padding-bottom: 5px;">Samsung</h4>
+                <h4 class="brand-title">Samsung</h4>
                 <table class="products-table">
                     <thead>
                         <tr>
@@ -1202,7 +1211,7 @@
                     </tbody>
                 </table>
                 
-                <h4 style="margin-top: 20px; margin-bottom: 10px; color: #fff; border-bottom: 1px solid rgba(255,255,255,0.1); padding-bottom: 5px;">Xiaomi</h4>
+                <h4 class="brand-title">Xiaomi</h4>
                 <table class="products-table">
                     <thead>
                         <tr>
@@ -1295,7 +1304,7 @@
                 </table>
                 
                 <!-- Continúa con otras marcas de smartphones -->
-                <h4 style="margin-top: 20px; margin-bottom: 10px; color: #fff; border-bottom: 1px solid rgba(255,255,255,0.1); padding-bottom: 5px;">Google</h4>
+                <h4 class="brand-title">Google</h4>
                 <table class="products-table">
                     <thead>
                         <tr>
@@ -1352,7 +1361,7 @@
                     </tbody>
                 </table>
                 
-                <h4 style="margin-top: 20px; margin-bottom: 10px; color: #fff; border-bottom: 1px solid rgba(255,255,255,0.1); padding-bottom: 5px;">Motorola</h4>
+                <h4 class="brand-title">Motorola</h4>
                 <table class="products-table">
                     <thead>
                         <tr>
@@ -1380,7 +1389,7 @@
                         </tr>
                     </tbody>
                 </table>
-                <h4 style="margin-top: 20px; margin-bottom: 10px; color: #fff; border-bottom: 1px solid rgba(255,255,255,0.1); padding-bottom: 5px;">OnePlus</h4>
+                <h4 class="brand-title">OnePlus</h4>
                 <table class="products-table">
                     <thead>
                         <tr>
@@ -1409,7 +1418,7 @@
                     </tbody>
                 </table>
 
-                <h4 style="margin-top: 20px; margin-bottom: 10px; color: #fff; border-bottom: 1px solid rgba(255,255,255,0.1); padding-bottom: 5px;">OPPO</h4>
+                <h4 class="brand-title">OPPO</h4>
                 <table class="products-table">
                     <thead>
                         <tr>
@@ -1452,7 +1461,7 @@
                     </tbody>
                 </table>
 
-                <h4 style="margin-top: 20px; margin-bottom: 10px; color: #fff; border-bottom: 1px solid rgba(255,255,255,0.1); padding-bottom: 5px;">Honor</h4>
+                <h4 class="brand-title">Honor</h4>
                 <table class="products-table">
                     <thead>
                         <tr>
@@ -1474,7 +1483,7 @@
                     </tbody>
                 </table>
 
-                <h4 style="margin-top: 20px; margin-bottom: 10px; color: #fff; border-bottom: 1px solid rgba(255,255,255,0.1); padding-bottom: 5px;">Huawei</h4>
+                <h4 class="brand-title">Huawei</h4>
                 <table class="products-table">
                     <thead>
                         <tr>
@@ -1489,7 +1498,7 @@
                     </tbody>
                 </table>
 
-                <h4 style="margin-top: 20px; margin-bottom: 10px; color: #fff; border-bottom: 1px solid rgba(255,255,255,0.1); padding-bottom: 5px;">Realme</h4>
+                <h4 class="brand-title">Realme</h4>
                 <table class="products-table">
                     <thead>
                         <tr>
@@ -1504,7 +1513,7 @@
                     </tbody>
                 </table>
 
-                <h4 style="margin-top: 20px; margin-bottom: 10px; color: #fff; border-bottom: 1px solid rgba(255,255,255,0.1); padding-bottom: 5px;">Nubia</h4>
+                <h4 class="brand-title">Nubia</h4>
                 <table class="products-table">
                     <thead>
                         <tr>
@@ -1519,7 +1528,7 @@
                     </tbody>
                 </table>
 
-                <h4 style="margin-top: 20px; margin-bottom: 10px; color: #fff; border-bottom: 1px solid rgba(255,255,255,0.1); padding-bottom: 5px;">Vivo</h4>
+                <h4 class="brand-title">Vivo</h4>
                 <table class="products-table">
                     <thead>
                         <tr>
@@ -1545,7 +1554,7 @@
             <div class="product-category" id="tablets">
                 <h3 class="category-title">Tablets</h3>
                 
-                <h4 style="margin-top: 20px; margin-bottom: 10px; color: #fff; border-bottom: 1px solid rgba(255,255,255,0.1); padding-bottom: 5px;">Apple</h4>
+                <h4 class="brand-title">Apple</h4>
                 <table class="products-table">
                     <thead>
                         <tr>
@@ -1574,7 +1583,7 @@
                     </tbody>
                 </table>
                 
-                <h4 style="margin-top: 20px; margin-bottom: 10px; color: #fff; border-bottom: 1px solid rgba(255,255,255,0.1); padding-bottom: 5px;">Samsung</h4>
+                <h4 class="brand-title">Samsung</h4>
                 <table class="products-table">
                     <thead>
                         <tr>
@@ -1603,7 +1612,7 @@
                     </tbody>
                 </table>
                 
-                <h4 style="margin-top: 20px; margin-bottom: 10px; color: #fff; border-bottom: 1px solid rgba(255,255,255,0.1); padding-bottom: 5px;">Xiaomi</h4>
+                <h4 class="brand-title">Xiaomi</h4>
                 <table class="products-table">
                     <thead>
                         <tr>
@@ -1636,7 +1645,7 @@
             <div class="product-category" id="smartwatches">
                 <h3 class="category-title">Smartwatches y Wearables</h3>
                 
-                <h4 style="margin-top: 20px; margin-bottom: 10px; color: #fff; border-bottom: 1px solid rgba(255,255,255,0.1); padding-bottom: 5px;">Apple</h4>
+                <h4 class="brand-title">Apple</h4>
                 <table class="products-table">
                     <thead>
                         <tr>
@@ -1665,7 +1674,7 @@
                     </tbody>
                 </table>
                 
-                <h4 style="margin-top: 20px; margin-bottom: 10px; color: #fff; border-bottom: 1px solid rgba(255,255,255,0.1); padding-bottom: 5px;">Samsung</h4>
+                <h4 class="brand-title">Samsung</h4>
                 <table class="products-table">
                     <thead>
                         <tr>
@@ -1694,7 +1703,7 @@
                     </tbody>
                 </table>
                 
-                <h4 style="margin-top: 20px; margin-bottom: 10px; color: #fff; border-bottom: 1px solid rgba(255,255,255,0.1); padding-bottom: 5px;">Xiaomi</h4>
+                <h4 class="brand-title">Xiaomi</h4>
                 <table class="products-table">
                     <thead>
                         <tr>
@@ -1727,7 +1736,7 @@
             <div class="product-category" id="audio">
                 <h3 class="category-title">Auriculares y Audio</h3>
                 
-                <h4 style="margin-top: 20px; margin-bottom: 10px; color: #fff; border-bottom: 1px solid rgba(255,255,255,0.1); padding-bottom: 5px;">Apple</h4>
+                <h4 class="brand-title">Apple</h4>
                 <table class="products-table">
                     <thead>
                         <tr>
@@ -1756,7 +1765,7 @@
                     </tbody>
                 </table>
                 
-                <h4 style="margin-top: 20px; margin-bottom: 10px; color: #fff; border-bottom: 1px solid rgba(255,255,255,0.1); padding-bottom: 5px;">Samsung</h4>
+                <h4 class="brand-title">Samsung</h4>
                 <table class="products-table">
                     <thead>
                         <tr>
@@ -1790,7 +1799,7 @@
             <div class="product-category" id="tv">
                 <h3 class="category-title">Televisores y Dispositivos Streaming</h3>
                 
-                <h4 style="margin-top: 20px; margin-bottom: 10px; color: #fff; border-bottom: 1px solid rgba(255,255,255,0.1); padding-bottom: 5px;">Smart TV</h4>
+                <h4 class="brand-title">Smart TV</h4>
                 <table class="products-table">
                     <thead>
                         <tr>
@@ -1819,7 +1828,7 @@
                     </tbody>
                 </table>
                 
-                <h4 style="margin-top: 20px; margin-bottom: 10px; color: #fff; border-bottom: 1px solid rgba(255,255,255,0.1); padding-bottom: 5px;">Dispositivos Streaming</h4>
+                <h4 class="brand-title">Dispositivos Streaming</h4>
                 <table class="products-table">
                     <thead>
                         <tr>
@@ -1876,7 +1885,7 @@
             <div class="product-category" id="gaming">
                 <h3 class="category-title">Videojuegos y Consolas</h3>
                 
-                <h4 style="margin-top: 20px; margin-bottom: 10px; color: #fff; border-bottom: 1px solid rgba(255,255,255,0.1); padding-bottom: 5px;">Consolas</h4>
+                <h4 class="brand-title">Consolas</h4>
                 <table class="products-table">
                     <thead>
                         <tr>
@@ -1923,7 +1932,7 @@
             <div class="product-category" id="accesorios">
                 <h3 class="category-title">Accesorios</h3>
                 
-                <h4 style="margin-top: 20px; margin-bottom: 10px; color: #fff; border-bottom: 1px solid rgba(255,255,255,0.1); padding-bottom: 5px;">Cargadores y Cables</h4>
+                <h4 class="brand-title">Cargadores y Cables</h4>
                 <table class="products-table">
                     <thead>
                         <tr>
@@ -1952,7 +1961,7 @@
                     </tbody>
                 </table>
                 
-                <h4 style="margin-top: 20px; margin-bottom: 10px; color: #fff; border-bottom: 1px solid rgba(255,255,255,0.1); padding-bottom: 5px;">Airtags y Rastreadores</h4>
+                <h4 class="brand-title">Airtags y Rastreadores</h4>
                 <table class="products-table">
                     <thead>
                         <tr>


### PR DESCRIPTION
## Summary
- add reusable `.brand-title` style for catalog brand headings
- clean up catalog markup to use the new class and avoid overlapping titles

## Testing
- `htmlhint index.html` *(fails: command not found)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf60825c3083248b2bf7e0dc2ea61b