### PR TITLE
Indicate missing selections on payment flow

### DIFF
--- a/pagos.html
+++ b/pagos.html
@@ -276,7 +276,7 @@
                                         </div>
 
                                         <div class="checkout-actions">
-                                            <button class="btn btn-primary btn-block" id="continue-to-shipping" disabled>
+                                            <button class="btn btn-primary btn-block" id="continue-to-shipping">
                                                 <i class="fas fa-truck btn-icon"></i>Continuar con el envío
                                             </button>
                                         </div>
@@ -446,7 +446,7 @@
                     <button class="btn btn-secondary" id="back-to-products">
                         <i class="fas fa-arrow-left btn-icon"></i>Volver a productos
                     </button>
-                    <button class="btn btn-primary" id="continue-to-payment" disabled>
+                    <button class="btn btn-primary" id="continue-to-payment">
                         <i class="fas fa-credit-card btn-icon"></i>Continuar al pago
                     </button>
                 </div>

--- a/pagos.js
+++ b/pagos.js
@@ -737,9 +737,6 @@
                         </div>
                     `;
                     
-                    // Deshabilitar botón de continuar
-                    continueToShippingBtn.disabled = true;
-                    
                     // Actualizar resumen
                     updateOrderSummary();
                     return;
@@ -846,9 +843,6 @@
                         removeFromCart(productId);
                     });
                 });
-                
-                // Habilitar botón de continuar
-                continueToShippingBtn.disabled = false;
                 
                 // Actualizar resumen
                 updateOrderSummary();
@@ -999,10 +993,7 @@
             }
 
             function updateContinueToPaymentBtnState() {
-                const shippingSelected = document.querySelector('.shipping-option.selected');
-                const companySelected = document.querySelector('.shipping-company-option.selected');
-                const insuranceSelected = document.querySelector('.insurance-option.selected');
-                continueToPaymentBtn.disabled = !(shippingSelected && companySelected && insuranceSelected && acceptTaxCheckbox.checked);
+                // La validación se realiza al intentar continuar al pago.
             }
 
             // Función para cambiar de paso
@@ -1131,6 +1122,7 @@
                 // Validar información de tarjeta si es el método seleccionado
                 const selectedPaymentOption = document.querySelector('.payment-option.selected');
                 if (!selectedPaymentOption) {
+                    showToast('error', 'Método de pago', 'Por favor, selecciona un método de pago.');
                     return;
                 }
                 const selectedPaymentMethod = selectedPaymentOption.getAttribute('data-payment');
@@ -1490,7 +1482,25 @@
             });
 
             continueToPaymentBtn.addEventListener('click', () => {
-                if (continueToPaymentBtn.disabled) return;
+                const missing = [];
+                if (!document.querySelector('.shipping-option.selected')) {
+                    missing.push('el método de envío');
+                }
+                if (!document.querySelector('.shipping-company-option.selected')) {
+                    missing.push('la empresa de envío');
+                }
+                if (!document.querySelector('.insurance-option.selected')) {
+                    missing.push('una opción de seguro');
+                }
+                if (!acceptTaxCheckbox.checked) {
+                    missing.push('aceptar la tasa de nacionalización');
+                }
+
+                if (missing.length > 0) {
+                    showToast('warning', 'Faltan datos', `Para continuar, debes seleccionar ${missing.join(', ')}.`);
+                    return;
+                }
+
                 goToStep(3);
                 updatePaymentSummary();
             });
@@ -1600,8 +1610,7 @@
 
                     // Seleccionar esta opción
                     option.classList.add('selected');
-                    processPaymentBtn.disabled = false;
-                    
+
                     // Notificar al usuario
                     showToast('info', 'Método de pago', `Has seleccionado ${option.getAttribute('data-payment')} como método de pago.`);
                 });
@@ -1654,5 +1663,4 @@
 
             updateSelectionSummary();
             updateContinueToPaymentBtnState();
-            processPaymentBtn.disabled = true;
         });


### PR DESCRIPTION
## Summary
- Allow checkout navigation buttons to be clickable and report missing information
- Warn the user which shipping, company, insurance or tax selections are missing before advancing to payment
- Show an error if attempting to pay without selecting a payment method

## Testing
- `npm test` *(fails: enoent Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf62df98f48324bfdc05a425db63c0