### PR TITLE
Display pending nationalization fee in order details

### DIFF
--- a/pagos.html
+++ b/pagos.html
@@ -618,6 +618,10 @@
                             <div class="order-detail-label">Tasa de cambio aplicada:</div>
                             <div class="order-detail-value">1 USD = 225 Bs</div>
                         </div>
+                        <div class="order-detail-row">
+                            <div class="order-detail-label">Tasa de nacionalización pendiente:</div>
+                            <div class="order-detail-value"><span id="order-nationalization">0.00 Bs</span></div>
+                        </div>
                     </div>
 
                     <div class="order-qr">

--- a/pagos.js
+++ b/pagos.js
@@ -80,6 +80,7 @@
             const nationalizationOverlay = document.getElementById('nationalization-overlay');
             const closeNationalizationBtn = document.getElementById('close-nationalization');
             const orderTotal = document.getElementById('order-total');
+            const orderNationalization = document.getElementById('order-nationalization');
             const shippingMethod = document.getElementById('shipping-method');
             const shippingCompanyElement = document.getElementById('shipping-company');
             const giftGrid = document.getElementById('gift-grid');
@@ -946,6 +947,7 @@
                 const nationalizationFeeValue = calculateNationalizationFee(total);
                 nationalizationFee.textContent = nationalizationFeeValue.toFixed(2);
                 nationalizationModalFee.textContent = nationalizationFeeValue.toFixed(2) + " Bs";
+                orderNationalization.textContent = nationalizationFeeValue.toFixed(2) + " Bs";
                 
                 // Actualizar también el resumen de los productos en la sección de pago
                 updatePaymentSummary();


### PR DESCRIPTION
## Summary
- Show pending nationalization fee amount in order confirmation details
- Populate nationalization fee info during order summary updates

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf66def5488324a365ccf7abbe3630