### PR TITLE
Destacar tasa de nacionalización pendiente

### DIFF
--- a/pagos.css
+++ b/pagos.css
@@ -2031,6 +2031,15 @@
             text-align: right;
         }
 
+        .order-detail-label.nationalization-warning,
+        .nationalization-remaining-note {
+            color: #ff0000;
+        }
+
+        .nationalization-remaining-note {
+            font-size: 1.4rem;
+        }
+
         .order-qr {
             max-width: 20rem;
             margin: 0 auto 5rem;

--- a/pagos.html
+++ b/pagos.html
@@ -619,9 +619,10 @@
                             <div class="order-detail-value">1 USD = 225 Bs</div>
                         </div>
                         <div class="order-detail-row">
-                            <div class="order-detail-label">Tasa de nacionalización pendiente:</div>
+                            <div class="order-detail-label nationalization-warning">Tasa de nacionalización pendiente:</div>
                             <div class="order-detail-value"><span id="order-nationalization">0.00 Bs</span></div>
                         </div>
+                        <p class="nationalization-remaining-note">Podrás pagarlo accediendo a la sección <strong>Mi cuenta</strong> y luego en la opción <strong>Pago de nacionalización</strong>.</p>
                     </div>
 
                     <div class="order-qr">


### PR DESCRIPTION
## Summary
- Resalta en rojo la tasa de nacionalización pendiente dentro de los detalles de la orden.
- Indica al usuario que puede pagar la tasa desde **Mi cuenta** en la opción **Pago de nacionalización**.

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf6cb4bb7c8324bfb378346d12655f