### PR TITLE
Add nationalization payment link in account sidebar

### DIFF
--- a/micuenta.html
+++ b/micuenta.html
@@ -199,6 +199,7 @@
         <div class="side-item" data-view="invoices"><span class="dot"></span><span>Facturas</span></div>
         <div class="side-item" data-view="claims"><span class="dot"></span><span>Mis reclamos</span></div>
         <div class="side-item" data-view="insurance"><span class="dot"></span><span>Seguros</span></div>
+        <a href="na.html" class="side-item" style="color:inherit"><span class="dot"></span><span>Mis pagos pendientes / nacionalización</span></a>
       </div>
 
       <div class="side-section">


### PR DESCRIPTION
## Summary
- add navigation option for pending nationalization payments in micuenta.html linking to na.html

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf6d116db48324acc223e4a9913b07