### PR TITLE
feat: sync nationalization info and hide after payment

### DIFF
--- a/micuenta.html
+++ b/micuenta.html
@@ -199,7 +199,7 @@
         <div class="side-item" data-view="invoices"><span class="dot"></span><span>Facturas</span></div>
         <div class="side-item" data-view="claims"><span class="dot"></span><span>Mis reclamos</span></div>
         <div class="side-item" data-view="insurance"><span class="dot"></span><span>Seguros</span></div>
-        <a href="na.html" class="side-item" style="color:inherit"><span class="dot"></span><span>Mis pagos pendientes / nacionalización</span></a>
+        <a id="linkNacionalizacion" href="na.html" class="side-item" style="color:inherit"><span class="dot"></span><span>Mis pagos pendientes / nacionalización</span></a>
       </div>
 
       <div class="side-section">
@@ -1061,6 +1061,10 @@
     /** Init **/
     function init(){
       seedIfEmpty();
+      const natLink = document.getElementById('linkNacionalizacion');
+      const pendingNat = localStorage.getItem('lpPendingNationalization');
+      const natDone = localStorage.getItem('lpNationalizationDone');
+      if(!pendingNat || natDone === 'true'){ natLink.style.display='none'; }
       const u = getLS('lpUser',{});
       $('#userName').textContent = u.name || 'Cliente';
       $('#userLevel').textContent = u.level || 'Miembro';

--- a/na.html
+++ b/na.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Pago de Nacionalización — Orden LP-X9D8NVWE</title>
+<title>Pago de Nacionalización</title>
 <style>
   :root{
     --primary:#0b5fff; --ink:#1a1f36; --muted:#6b7280;
@@ -48,7 +48,6 @@
   .step.current{background:#eff6ff;border-color:#bfdbfe}
   .step.current:before{background:#3b82f6;border-color:#1d4ed8}
   .carrier{display:flex;align-items:center;gap:10px}
-  .carrier img{height:26px}
   /* Success overlay */
   .success{
     position:fixed;inset:0;background:rgba(15,23,42,.6);
@@ -103,12 +102,12 @@
           <div style="width:42px;height:42px;border-radius:12px;background:var(--primary);color:#fff;display:grid;place-items:center;font-weight:800;">LP</div>
           <div>
             <h1>Pago de nacionalización</h1>
-            <div class="badge">Orden: LP-X9D8NVWE</div>
+            <div class="badge" id="orderBadge"></div>
           </div>
         </div>
         <div class="carrier">
           <span class="help">Transporte</span>
-          <img src="https://libertyexpress.com/wp-content/themes/kutis/assets/svg/logo_banner.svg" alt="Liberty Express">
+          <span id="carrierName"></span>
         </div>
       </header>
 
@@ -116,7 +115,7 @@
         <!-- Instrucciones de Pago Móvil -->
         <section class="panel">
           <h3>Datos para Pago Móvil</h3>
-          <div class="kv"><b>Monto a cancelar</b> <span class="amount">6.473,70 Bs</span></div>
+          <div class="kv"><b>Monto a cancelar</b> <span class="amount" id="amountBs"></span></div>
           <div class="copyrow">
             <div class="pill"><b>Teléfono receptor:</b> 0414-4272486</div>
             <button class="copy" data-copy="04144272486">Copiar</button>
@@ -130,26 +129,24 @@
             <button class="copy" data-copy="Bancamiga">Copiar</button>
           </div>
           <div class="copyrow">
-            <div class="pill"><b>Concepto / Referencia:</b> LP-X9D8NVWE</div>
-            <button class="copy" data-copy="LP-X9D8NVWE">Copiar</button>
+            <div class="pill"><b>Concepto / Referencia:</b> <span id="conceptOrder"></span></div>
+            <button class="copy" id="copyConcept">Copiar</button>
           </div>
           <p class="help">Realiza el Pago Móvil por el monto exacto e introduce como <b>concepto</b> tu número de orden.</p>
 
           <h3 style="margin-top:14px">Seguimiento</h3>
           <div class="timeline" aria-label="Línea de tiempo">
             <div class="step done">
-              <b>Compra</b><div class="help">07/09/2025</div>
+              <b>Compra</b><div class="help" id="purchaseDate"></div>
             </div>
             <div class="step current">
               <b>Nacionalización</b><div class="help">En curso</div>
             </div>
             <div class="step">
-              <b>Retiro</b><div class="help">En 3 días (10/09/2025)</div>
+              <b>Retiro</b><div class="help" id="etaInfo"></div>
             </div>
           </div>
-          <p class="help" style="margin-top:10px">
-            <b>Retiro exclusivo del titular:</b> Winder Manuel Fernández Avellaneda (presentar cédula).
-          </p>
+          <p class="help" id="pickupText" style="margin-top:10px"></p>
         </section>
 
         <!-- Formulario de carga de comprobante -->
@@ -159,11 +156,11 @@
             <div class="row">
               <div>
                 <label>Orden</label>
-                <input type="text" value="LP-X9D8NVWE" readonly>
+                <input id="formOrder" type="text" readonly>
               </div>
               <div>
                 <label>Monto (Bs)</label>
-                <input type="text" value="6473,70" readonly>
+                <input id="formAmount" type="text" readonly>
               </div>
             </div>
 
@@ -235,7 +232,7 @@
         <svg viewBox="0 0 48 48"><path d="M10 26 L20 36 L38 14"/></svg>
       </div>
       <h2 style="margin:6px 0 4px">¡Comprobante recibido!</h2>
-      <p class="help">Guardamos tu reporte de pago de nacionalización para la orden <b>LP-X9D8NVWE</b>.<br>Pronto recibirás la confirmación de verificación.</p>
+      <p class="help">Guardamos tu reporte de pago de nacionalización para la orden <b id="successOrder"></b>.<br>Pronto recibirás la confirmación de verificación.</p>
       <div class="actions" style="justify-content:center;margin-top:8px">
         <button class="btn primary" onclick="closeSuccess()">Aceptar</button>
       </div>
@@ -243,6 +240,29 @@
   </div>
 
 <script>
+  const pending = JSON.parse(localStorage.getItem('lpPendingNationalization') || 'null');
+  const user = JSON.parse(localStorage.getItem('lpUser') || '{}');
+  const fmtBs = new Intl.NumberFormat('es-VE',{style:'currency',currency:'VES'});
+  let orderId = pending ? pending.orderId : '';
+  let amountBs = pending ? parseFloat(pending.amountBs || '0') : 0;
+  if(pending){
+    document.title = `Pago de Nacionalización — Orden ${orderId}`;
+    document.getElementById('orderBadge').textContent = `Orden: ${orderId}`;
+    document.getElementById('amountBs').textContent = fmtBs.format(amountBs);
+    document.getElementById('conceptOrder').textContent = orderId;
+    document.getElementById('copyConcept').dataset.copy = orderId;
+    document.getElementById('formOrder').value = orderId;
+    document.getElementById('formAmount').value = fmtBs.format(amountBs).replace('Bs','').trim();
+    document.getElementById('purchaseDate').textContent = pending.date || '';
+    if(pending.eta){
+      const diffDays = Math.max(0, Math.ceil((new Date(pending.eta) - new Date())/86400000));
+      document.getElementById('etaInfo').textContent = `En ${diffDays} días (${pending.eta})`;
+    }
+    document.getElementById('pickupText').innerHTML = `<b>Retiro exclusivo del titular:</b> ${user.name || ''} (presentar cédula).`;
+    document.getElementById('successOrder').textContent = orderId;
+    document.getElementById('carrierName').textContent = pending.courier || '';
+  }
+
   // Prefija la fecha con hoy
   document.querySelector('input[name="fechaPago"]').valueAsDate = new Date();
 
@@ -287,8 +307,8 @@
     const b64 = await toBase64(file);
 
     const payload = {
-      order: 'LP-X9D8NVWE',
-      amount_bs: '6473,70',
+      order: orderId,
+      amount_bs: fmtBs.format(amountBs).replace('Bs','').trim(),
       tel_pagador: form.telPagador.value.trim(),
       ci_pagador: form.cedulaPagador.value.trim(),
       banco_emisor: form.bancoEmisor.value.trim(),
@@ -298,7 +318,9 @@
       file_type: file.type,
       file_b64: b64
     };
-    localStorage.setItem('lp_nacionalizacion_LP-X9D8NVWE', JSON.stringify(payload));
+    localStorage.setItem(`lp_nacionalizacion_${orderId}`, JSON.stringify(payload));
+    localStorage.removeItem('lpPendingNationalization');
+    localStorage.setItem('lpNationalizationDone','true');
 
     // Mostrar éxito + confetti
     openSuccess();

--- a/pagos.js
+++ b/pagos.js
@@ -1312,10 +1312,13 @@
                 const tax = subtotal * taxRate;
                 const total = subtotal + tax + selectedShipping.price + selectedInsurance.price;
 
+                const nationalizationFeeValue = calculateNationalizationFee(total);
+
                 const order = {
                     id: orderNumber,
                     date: today,
                     total: total,
+                    nationalizationFeeBs: nationalizationFeeValue,
                     status: 'En preparación',
                     items: cart.map(item => ({
                         sku: item.id,
@@ -1334,6 +1337,14 @@
                 const orders = JSON.parse(localStorage.getItem('lpOrders') || '[]');
                 orders.push(order);
                 localStorage.setItem('lpOrders', JSON.stringify(orders));
+                localStorage.setItem('lpPendingNationalization', JSON.stringify({
+                    orderId: orderNumber,
+                    amountBs: nationalizationFeeValue.toFixed(2),
+                    date: today,
+                    eta: eta,
+                    courier: selectedShippingCompany || ''
+                }));
+                localStorage.removeItem('lpNationalizationDone');
 
                 const user = {
                     name: fullNameInput ? fullNameInput.value : '',


### PR DESCRIPTION
## Summary
- store nationalization fee and pending payment details after checkout
- populate na.html from local data and mark payment as done after receipt upload
- hide nationalization link in account once payment is submitted

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf6e2a5c8c8324bcf9f431eee981df