### PR TITLE
Improve micuenta.html responsiveness and gating

### DIFF
--- a/account.js
+++ b/account.js
@@ -15,7 +15,9 @@
       link.style.display = 'inline-block';
       link.classList && link.classList.remove('disabled');
       link.removeAttribute('aria-disabled');
-      link.setAttribute('href','micuenta.html');
+      const user = JSON.parse(localStorage.getItem('lpUser') || '{}');
+      const hasInfo = user.name && user.email && user.phone;
+      link.setAttribute('href', hasInfo ? 'micuenta.html' : 'informacion.html');
     }
   });
 })();

--- a/micuenta.html
+++ b/micuenta.html
@@ -2,7 +2,7 @@
 <html lang="es" class="h-full">
 <head>
   <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
   <title>Mi Cuenta — Panel de Usuario</title>
   <meta name="description" content="Panel de control del cliente: pedidos, reclamos, seguimiento, seguros, facturas y más." />
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -28,7 +28,7 @@
       --shadow-soft:0 6px 20px rgba(17,24,39,.06);
     }
     *{box-sizing:border-box}
-    html,body{height:100%}
+    html,body{min-height:100%;overflow-x:hidden}
     body{
       margin:0;
       font-family:'Inter',system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;
@@ -1059,7 +1059,15 @@
     }
 
     /** Init **/
+    function hasUserInfo(){
+      const u = getLS('lpUser',{});
+      return u.name && u.email && u.phone;
+    }
     function init(){
+      if(!hasUserInfo()){
+        window.location.href = './informacion.html';
+        return;
+      }
       seedIfEmpty();
       const u = getLS('lpUser',{});
       $('#userName').textContent = u.name || 'Cliente';

--- a/pagos.js
+++ b/pagos.js
@@ -1372,8 +1372,9 @@
                 updateCartCount();
                 if (accountLink) {
                     accountLink.classList.remove('disabled');
-                    accountLink.setAttribute('href', 'micuenta.html');
                     accountLink.removeAttribute('aria-disabled');
+                    const hasInfo = user.name && user.email && user.phone;
+                    accountLink.setAttribute('href', hasInfo ? 'micuenta.html' : 'informacion.html');
                 }
 
                 // Pago exitoso, avanzar a la confirmación


### PR DESCRIPTION
## Summary
- Prevent page zoom and horizontal overflow on the account page for a mobile‑first layout
- Restrict access to `micuenta.html` until required user info exists
- Link "Mi cuenta" to profile completion when info is missing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf6f3f5f508324bebb93d16759e2b3