### PR TITLE
feat: persist payment data

### DIFF
--- a/pagos.js
+++ b/pagos.js
@@ -165,6 +165,7 @@
             let selectedGift = null;
             let selectedPaymentMethod = null;
             let orderNumber = '';
+            let orderSaved = false;
             let preselectedProductName = localStorage.getItem('selectedProduct');
             const exchangeRate = 225; // 1 USD = 225 Bs
             const taxRate = 0.16; // 16% IVA
@@ -1282,6 +1283,9 @@
                 whatsappBtn.href = whatsappUrl;
                 whatsappSupport.href = whatsappUrl;
 
+                // Guardar datos de la compra inmediatamente
+                saveOrderData();
+
                 setTimeout(() => {
                     loadingOverlay.classList.remove('active');
                     nationalizationOverlay.classList.add('active');
@@ -1289,6 +1293,8 @@
             }
 
             function saveOrderData() {
+                if(orderSaved) return;
+                orderSaved = true;
                 const today = new Date().toISOString().slice(0,10);
                 const eta = (() => {
                     const end = new Date();


### PR DESCRIPTION
## Summary
- persist order information in `pagos.js` as soon as a payment is processed so it survives page refreshes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf6f7aaa608324a4e8a29f325e46b3