### PR TITLE
Display cart icon and persist cart data

### DIFF
--- a/index.html
+++ b/index.html
@@ -183,6 +183,23 @@
             box-shadow: 0 10px 20px rgba(0, 0, 0, 0.2);
         }
 
+        .cart-link {
+            position: relative;
+            color: #fff;
+        }
+
+        .cart-count {
+            position: absolute;
+            top: -0.5rem;
+            right: -0.7rem;
+            background-color: var(--accent-color);
+            color: #fff;
+            border-radius: 50%;
+            padding: 0 0.4rem;
+            font-size: 0.75rem;
+            line-height: 1.2;
+        }
+
         .video-collage {
             display: grid;
             grid-template-columns: repeat(2, 1fr);
@@ -807,6 +824,7 @@
                 <li><a href="#nosotros">Nosotros</a></li>
                 <li><a href="#contacto">Contacto</a></li>
                 <li><a id="account-link" href="micuenta.html" style="display:none;">Mi cuenta</a></li>
+                <li><a href="carrito.html" class="cart-link"><i class="fas fa-shopping-cart"></i><span class="cart-count">0</span></a></li>
             </ul>
             <button class="mobile-nav-toggle" id="mobile-nav-toggle">
                 <i class="fas fa-bars"></i>
@@ -2258,6 +2276,20 @@
                     });
                 }
             });
+        });
+    </script>
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            const cartCountEl = document.querySelector('.cart-count');
+            if (cartCountEl) {
+                try {
+                    const storedCart = JSON.parse(localStorage.getItem('latinphone_cart')) || [];
+                    const count = storedCart.reduce((sum, item) => sum + (item.quantity || 0), 0);
+                    cartCountEl.textContent = count;
+                } catch (err) {
+                    console.error('Error al cargar el carrito', err);
+                }
+            }
         });
     </script>
 </body>

--- a/pagos.html
+++ b/pagos.html
@@ -26,7 +26,7 @@
         <a href="index.html" class="top-link"><i class="fas fa-home"></i> Inicio</a>
         <div class="top-right">
             <a href="#" class="top-link disabled" id="account-link" aria-disabled="true"><i class="fas fa-user"></i> Mi cuenta</a>
-            <div class="top-link cart-indicator"><i class="fas fa-shopping-cart"></i><span id="cart-count">0</span></div>
+            <a href="carrito.html" class="top-link cart-indicator"><i class="fas fa-shopping-cart"></i><span id="cart-count">0</span></a>
         </div>
     </nav>
     <div class="checkout-container">

--- a/pagos.js
+++ b/pagos.js
@@ -155,7 +155,15 @@
             }
 
             // Variables para almacenar el estado del pedido
-            const cart = [];
+            let cart = [];
+            try {
+                const storedCart = JSON.parse(localStorage.getItem('latinphone_cart')) || [];
+                if (Array.isArray(storedCart)) {
+                    cart = storedCart;
+                }
+            } catch (err) {
+                console.error('Error al cargar el carrito desde localStorage', err);
+            }
             let selectedCountry = '';
             let selectedCategory = '';
             let selectedBrand = '';
@@ -972,6 +980,21 @@
                 
                 // Actualizar precio en la página de confirmación
                 orderTotal.textContent = `$${total.toFixed(2)}`;
+
+                // Guardar carrito y totales en localStorage
+                try {
+                    const totals = {
+                        subtotal,
+                        tax,
+                        shipping: shippingPrice,
+                        insurance: insurancePrice,
+                        total
+                    };
+                    localStorage.setItem('latinphone_cart', JSON.stringify(cart));
+                    localStorage.setItem('latinphone_cart_totals', JSON.stringify(totals));
+                } catch (err) {
+                    console.error('Error al guardar el carrito', err);
+                }
             }
 
             function updateSelectionSummary() {


### PR DESCRIPTION
## Summary
- Show shopping cart icon in home and payment pages
- Load and save cart information via localStorage
- Link cart from payment step and update counts across pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf7343f04883248e53c46b6b4108ff