### PR TITLE
Show account button after checkout

### DIFF
--- a/account.js
+++ b/account.js
@@ -1,7 +1,9 @@
 (function(){
   document.addEventListener('DOMContentLoaded', function(){
     const orders = JSON.parse(localStorage.getItem('lpOrders') || '[]');
-    if(!orders.length) return;
+    const addresses = JSON.parse(localStorage.getItem('lpAddresses') || '[]');
+    const invoices = JSON.parse(localStorage.getItem('lpInvoices') || '[]');
+    if(!orders.length || !addresses.length || !invoices.length) return;
     const lastOrder = orders[orders.length - 1];
     const eta = lastOrder.shipping && lastOrder.shipping.eta;
     const today = new Date().toISOString().slice(0,10);

--- a/index.html
+++ b/index.html
@@ -823,7 +823,7 @@
                 <li><a href="#productos">Productos</a></li>
                 <li><a href="#nosotros">Nosotros</a></li>
                 <li><a href="#contacto">Contacto</a></li>
-                <li><a id="account-link" href="micuenta.html" style="display:none;">Mi cuenta</a></li>
+                <li><a href="#" id="account-link" class="disabled" aria-disabled="true" style="display:none;">Mi cuenta</a></li>
                 <li><a href="carrito.html" class="cart-link"><i class="fas fa-shopping-cart"></i><span class="cart-count">0</span></a></li>
             </ul>
             <button class="mobile-nav-toggle" id="mobile-nav-toggle">

--- a/pagos.html
+++ b/pagos.html
@@ -25,7 +25,7 @@
     <nav class="top-bar">
         <a href="index.html" class="top-link"><i class="fas fa-home"></i> Inicio</a>
         <div class="top-right">
-            <a href="#" class="top-link disabled" id="account-link" aria-disabled="true"><i class="fas fa-user"></i> Mi cuenta</a>
+            <a href="#" class="top-link disabled" id="account-link" aria-disabled="true" style="display:none;"><i class="fas fa-user"></i> Mi cuenta</a>
             <a href="carrito.html" class="top-link cart-indicator"><i class="fas fa-shopping-cart"></i><span id="cart-count">0</span></a>
         </div>
     </nav>

--- a/pagos.js
+++ b/pagos.js
@@ -1320,6 +1320,7 @@
                     const storedUser = JSON.parse(localStorage.getItem('lpUser') || '{}');
                     const hasInfo = storedUser.name && storedUser.email && storedUser.phone;
                     accountLink.setAttribute('href', hasInfo ? 'micuenta.html' : 'informacion.html');
+                    accountLink.style.display = 'inline-block';
                 }
 
                 setTimeout(() => {
@@ -1396,7 +1397,8 @@
                 };
                 localStorage.setItem('lpUser', JSON.stringify(user));
 
-                localStorage.setItem('lpInvoices', JSON.stringify([]));
+                const invoices = [{ id: 'INV-' + orderNumber, orderId: orderNumber, amount: total, date: today, paid: true }];
+                localStorage.setItem('lpInvoices', JSON.stringify(invoices));
                 localStorage.setItem('lpClaims', JSON.stringify([]));
 
                 const payments = [{ id: 'PM-1', brand: selectedPaymentMethod, last4: '', holder: user.name, exp: '', default: true }];


### PR DESCRIPTION
## Summary
- Display "Mi cuenta" after checkout only when order, address and invoice data exist
- Persist sample invoice during checkout to unlock account access
- Reveal account link on the payment page once the user finishes the process

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf74e435d08324ae5a6bf5d0aa6253