### PR TITLE
Fix overlapping product table headers

### DIFF
--- a/index.html
+++ b/index.html
@@ -374,7 +374,8 @@
             border-bottom: 1px solid rgba(255, 255, 255, 0.05);
             font-size: 0.85rem;
             white-space: normal;
-            word-break: normal;
+            word-break: break-word;
+            overflow-wrap: break-word;
         }
 
         .products-table th {
@@ -382,7 +383,7 @@
             color: rgba(255, 255, 255, 0.8);
             font-weight: 500;
             text-transform: uppercase;
-            font-size: 0.85rem;
+            font-size: 0.8rem;
             letter-spacing: 1px;
         }
 
@@ -756,7 +757,8 @@
                 padding: 6px 4px;
                 font-size: 0.7rem;
                 white-space: normal;
-                word-break: normal;
+                word-break: break-word;
+                overflow-wrap: break-word;
             }
 
             .buy-btn {
@@ -798,9 +800,10 @@
             .products-table th,
             .products-table td {
                 padding: 4px 3px;
-                font-size: 0.65rem;
+                font-size: 0.6rem;
                 white-space: normal;
-                word-break: normal;
+                word-break: break-word;
+                overflow-wrap: break-word;
             }
 
             .buy-btn {


### PR DESCRIPTION
## Summary
- Allow table headers to wrap and reduce their font size to prevent product catalog titles from overlapping
- Ensure responsive tables break long words on small screens

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf75d1e0b88324b1e3ebc592237452