### PR TITLE
Center gift grid and add validation overlay

### DIFF
--- a/pagos.css
+++ b/pagos.css
@@ -1299,10 +1299,11 @@
         }
 
         .gift-grid {
-            display: grid;
-            grid-template-columns: repeat(auto-fill, minmax(18rem, 1fr));
+            display: flex;
+            flex-wrap: wrap;
             gap: 2rem;
             margin-bottom: 4rem;
+            justify-content: center;
         }
 
         .gift-card {
@@ -2287,6 +2288,34 @@
             width: 90%;
         }
 
+        /* Overlay de validación */
+        .validation-overlay {
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: rgba(0, 0, 0, 0.4);
+            display: none;
+            align-items: center;
+            justify-content: center;
+            z-index: var(--z-overlay);
+        }
+
+        .validation-overlay.active {
+            display: flex;
+        }
+
+        .validation-modal {
+            background: var(--white);
+            padding: 3rem;
+            border-radius: var(--radius);
+            box-shadow: var(--shadow-lg);
+            text-align: center;
+            max-width: 40rem;
+            width: 90%;
+        }
+
         /* Loading Overlay mejorado */
         .loading-overlay {
             position: fixed;
@@ -2972,9 +3001,12 @@
 
             .category-grid,
             .brand-grid,
-            .product-grid,
-            .gift-grid {
+            .product-grid {
                 grid-template-columns: repeat(auto-fill, minmax(14rem, 1fr));
+                gap: 1.2rem;
+            }
+
+            .gift-grid {
                 gap: 1.2rem;
             }
 

--- a/pagos.html
+++ b/pagos.html
@@ -817,6 +817,14 @@
         </div>
     </div>
 
+    <!-- Overlay de validación -->
+    <div class="validation-overlay" id="validation-overlay">
+        <div class="validation-modal">
+            <p id="validation-message"></p>
+            <button class="btn btn-primary" id="validation-close">Entendido</button>
+        </div>
+    </div>
+
     <!-- Toast Notifications -->
     <div class="toast-container" id="toast-container">
         <!-- Toast notifications se agregarán aquí dinámicamente -->

--- a/pagos.js
+++ b/pagos.js
@@ -127,6 +127,9 @@
             const accountLink = document.getElementById('account-link');
             const accountOverlay = document.getElementById('account-overlay');
             const accountOverlayClose = document.getElementById('account-overlay-close');
+            const validationOverlay = document.getElementById('validation-overlay');
+            const validationMessage = document.getElementById('validation-message');
+            const validationClose = document.getElementById('validation-close');
 
             const sendDeliveryInfoBtn = document.getElementById('send-delivery-info');
             const fullNameInput = document.getElementById('full-name');
@@ -151,6 +154,12 @@
                     const encodedMessage = encodeURIComponent(message);
                     const whatsappUrl = `https://wa.me/+18133584564?text=${encodedMessage}`;
                     window.open(whatsappUrl, '_blank');
+                });
+            }
+
+            if (validationClose) {
+                validationClose.addEventListener('click', () => {
+                    validationOverlay.classList.remove('active');
                 });
             }
 
@@ -410,8 +419,20 @@
             let giftProducts = [];
 
             // Notificaciones deshabilitadas
+            function showValidationOverlay(message) {
+                if (validationMessage) {
+                    validationMessage.textContent = message;
+                }
+                if (validationOverlay) {
+                    validationOverlay.classList.add('active');
+                }
+            }
+
             function showToast(type, title, message, duration = 5000) {
                 console.log(`${title}: ${message}`);
+                if (type === 'error' || type === 'warning') {
+                    showValidationOverlay(`${title}: ${message}`);
+                }
             }
 
             function closeToast(toast) {}


### PR DESCRIPTION
## Summary
- center "Elige un regalo gratis" gift cards for balanced display
- add reusable validation overlay shown when required selections are missing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c050f9ff8c8324874ed3795d31a8b4