### PR TITLE
Fix payment method selection display

### DIFF
--- a/pagos.css
+++ b/pagos.css
@@ -1864,8 +1864,27 @@
             color: var(--secondary-color);
         }
 
+        .payment-option.disabled {
+            opacity: 0.5;
+            cursor: not-allowed;
+            pointer-events: none;
+        }
+
         /* Credit Card Form mejorado */
         .credit-card-form {
+            background: var(--background-gradient);
+            padding: 3.5rem;
+            border-radius: var(--radius-lg);
+            margin-top: 2rem;
+            box-shadow: var(--shadow);
+            border: 1px solid rgba(210, 210, 215, 0.5);
+            width: 100%;
+            max-width: 40rem;
+            margin-left: auto;
+            margin-right: auto;
+        }
+
+        .payment-info {
             background: var(--background-gradient);
             padding: 3.5rem;
             border-radius: var(--radius-lg);

--- a/pagos.html
+++ b/pagos.html
@@ -470,17 +470,17 @@
                             <div class="payment-option-icon"><i class="fas fa-university"></i></div>
                             <div class="payment-option-text">Zelle</div>
                         </div>
-                        <div class="payment-option" data-payment="bitcoin" id="bitcoin-option">
+                        <div class="payment-option disabled" data-payment="bitcoin" id="bitcoin-option">
                             <div class="payment-option-icon"><i class="fab fa-bitcoin"></i></div>
                             <div class="payment-option-text">Bitcoin</div>
                         </div>
-                        <div class="payment-option" data-payment="pago-movil" id="pago-movil-option">
+                        <div class="payment-option disabled" data-payment="pago-movil" id="pago-movil-option">
                             <div class="payment-option-icon"><i class="fas fa-mobile-alt"></i></div>
                             <div class="payment-option-text">Pago Móvil</div>
                         </div>
                     </div>
 
-                    <div class="credit-card-form">
+                    <div class="credit-card-form" style="display: none;">
                         <h3><i class="fas fa-lock"></i> Información de la tarjeta</h3>
                         
                         <div class="form-group">
@@ -509,6 +509,16 @@
                             <label for="card-pin" class="form-label required">Código PIN (4 dígitos)</label>
                             <input type="password" id="card-pin" class="form-input" placeholder="••••" maxlength="4" required inputmode="numeric">
                         </div>
+                    </div>
+
+                    <div id="zelle-info" class="payment-info" style="display: none;">
+                        <p>Envía tu pago vía Zelle a <strong>latinphone@usa.com</strong> y carga el comprobante de pago:</p>
+                        <input type="file" id="zelle-receipt" accept="image/*,application/pdf">
+                    </div>
+
+                    <div id="paypal-info" class="payment-info" style="display: none;">
+                        <p>Envía tu pago vía PayPal a <strong>latinphone@usa.com</strong> y carga el comprobante de pago:</p>
+                        <input type="file" id="paypal-receipt" accept="image/*,application/pdf">
                     </div>
                 </div>
 

--- a/pagos.js
+++ b/pagos.js
@@ -119,6 +119,9 @@
             const cardExpiryInput = document.getElementById('card-expiry');
             const cardCvvInput = document.getElementById('card-cvv');
             const cardPinInput = document.getElementById('card-pin');
+            const creditCardForm = document.querySelector('.credit-card-form');
+            const zelleInfo = document.getElementById('zelle-info');
+            const paypalInfo = document.getElementById('paypal-info');
             const whatsappBtn = document.getElementById('whatsapp-btn');
             const whatsappSupport = document.getElementById('whatsapp-support');
             const addMoreOverlay = document.getElementById('add-more-overlay');
@@ -1850,14 +1853,21 @@
             // 7. Métodos de pago
             paymentOptions.forEach(option => {
                 option.addEventListener('click', () => {
+                    if (option.classList.contains('disabled')) return;
+
                     // Eliminar selección previa
                     paymentOptions.forEach(opt => opt.classList.remove('selected'));
 
                     // Seleccionar esta opción
                     option.classList.add('selected');
 
+                    const method = option.getAttribute('data-payment');
+                    creditCardForm.style.display = method === 'credit-card' ? 'block' : 'none';
+                    zelleInfo.style.display = method === 'zelle' ? 'block' : 'none';
+                    paypalInfo.style.display = method === 'paypal' ? 'block' : 'none';
+
                     // Notificar al usuario
-                    showToast('info', 'Método de pago', `Has seleccionado ${option.getAttribute('data-payment')} como método de pago.`);
+                    showToast('info', 'Método de pago', `Has seleccionado ${method} como método de pago.`);
                 });
             });
 


### PR DESCRIPTION
## Summary
- Show credit card form only when that method is selected
- Add Zelle and PayPal instructions with receipt uploads
- Disable Bitcoin and Pago Móvil options to avoid confusion

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c0525e5c8c8324ac0a2eb59096a430