### PR TITLE
Allow removing items from payment summary

### DIFF
--- a/pagos.css
+++ b/pagos.css
@@ -970,7 +970,7 @@
             background-color: var(--light-gray);
             font-weight: 600;
             display: grid;
-            grid-template-columns: 1fr 10rem 15rem 10rem;
+            grid-template-columns: 1fr 10rem 15rem 10rem 4rem;
             gap: 1rem;
             align-items: center;
             border-bottom: 1px solid var(--border-color);
@@ -980,7 +980,7 @@
             padding: 2rem;
             border-bottom: 1px solid var(--border-color);
             display: grid;
-            grid-template-columns: 1fr 10rem 15rem 10rem;
+            grid-template-columns: 1fr 10rem 15rem 10rem 4rem;
             gap: 1rem;
             align-items: center;
             transition: var(--transition);

--- a/pagos.html
+++ b/pagos.html
@@ -533,6 +533,7 @@
                             <div>Precio</div>
                             <div>Cantidad</div>
                             <div>Subtotal</div>
+                            <div>Eliminar</div>
                         </div>
                         <div id="payment-summary-items">
                             <!-- Aquí se mostrará el resumen de los productos -->

--- a/pagos.js
+++ b/pagos.js
@@ -847,6 +847,7 @@
                         <div>Precio</div>
                         <div>Cantidad</div>
                         <div>Subtotal</div>
+                        <div>Eliminar</div>
                     </div>
                 `;
                 
@@ -1075,18 +1076,29 @@
                         <div class="item-price" data-label="Precio">$${item.price.toFixed(2)}</div>
                         <div class="item-quantity" data-label="Cantidad">${item.quantity}</div>
                         <div class="item-subtotal" data-label="Subtotal">$${subtotal.toFixed(2)}</div>
+                        <div class="item-actions">
+                            <span class="remove-item" data-id="${item.id}" role="button" aria-label="Eliminar artículo"><i class="fas fa-trash"></i></span>
+                        </div>
                     `;
-                    
+
                     paymentSummaryItems.appendChild(summaryItem);
                 });
-                
+
+                // Añadir eventos de eliminación para el resumen de pago
+                document.querySelectorAll('#payment-summary-items .remove-item').forEach(btn => {
+                    btn.addEventListener('click', () => {
+                        const productId = btn.getAttribute('data-id');
+                        removeFromCart(productId);
+                    });
+                });
+
                 // Si hay regalo seleccionado, añadirlo al resumen
                 if (selectedGift) {
                     const giftItem = document.createElement('div');
                     giftItem.className = 'cart-item';
-                    
+
                     const icon = defaultIcons[selectedGift.category] || 'fas fa-gift';
-                    
+
                     giftItem.innerHTML = `
                         <div class="item-details">
                             <div class="item-image-container">
@@ -1101,7 +1113,7 @@
                         <div class="item-quantity" data-label="Cantidad">1</div>
                         <div class="item-subtotal" data-label="Subtotal">$0.00</div>
                     `;
-                    
+
                     paymentSummaryItems.appendChild(giftItem);
                 }
             }


### PR DESCRIPTION
## Summary
- Let users remove items from the payment summary before completing checkout
- Add delete column to payment and cart headers for consistency
- Expand cart layout to include action column

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c05343ed388324bf7393445781be99