### PR TITLE
Show custom images for payment methods

### DIFF
--- a/pagos.css
+++ b/pagos.css
@@ -1856,6 +1856,14 @@
         .payment-option-icon {
             font-size: 2.4rem;
             color: var(--primary-color);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+
+        .payment-option-icon img {
+            width: 5rem;
+            height: auto;
         }
 
         .payment-option-text {

--- a/pagos.html
+++ b/pagos.html
@@ -459,7 +459,9 @@
                 <div class="payment-methods">
                     <div class="payment-options">
                         <div class="payment-option" data-payment="credit-card">
-                            <div class="payment-option-icon"><i class="fas fa-credit-card"></i></div>
+                            <div class="payment-option-icon">
+                                <img src="https://bukolica.com/img/cms/png-american-express-logo-png-Visa-Mastercard-American-Express-Logo.png" alt="Tarjeta">
+                            </div>
                             <div class="payment-option-text">Tarjeta</div>
                         </div>
                         <div class="payment-option" data-payment="paypal" id="paypal-option">
@@ -467,15 +469,21 @@
                             <div class="payment-option-text">PayPal</div>
                         </div>
                         <div class="payment-option" data-payment="zelle" id="zelle-option">
-                            <div class="payment-option-icon"><i class="fas fa-university"></i></div>
+                            <div class="payment-option-icon">
+                                <img src="https://www.logo.wine/a/logo/Zelle_(payment_service)/Zelle_(payment_service)-Logo.wine.svg" alt="Zelle">
+                            </div>
                             <div class="payment-option-text">Zelle</div>
                         </div>
                         <div class="payment-option disabled" data-payment="bitcoin" id="bitcoin-option">
-                            <div class="payment-option-icon"><i class="fab fa-bitcoin"></i></div>
+                            <div class="payment-option-icon">
+                                <img src="https://www.logo.wine/a/logo/Bitcoin/Bitcoin-Logo.wine.svg" alt="Bitcoin">
+                            </div>
                             <div class="payment-option-text">Bitcoin</div>
                         </div>
                         <div class="payment-option disabled" data-payment="pago-movil" id="pago-movil-option">
-                            <div class="payment-option-icon"><i class="fas fa-mobile-alt"></i></div>
+                            <div class="payment-option-icon">
+                                <img src="https://lh3.googleusercontent.com/proxy/iwoy5cVOOpFaH3kVTHpyuDnve-xJMY_wdw62zu9PRPLEIxcJMgN05vagAdlMzl-mgp8K_RpXhGqnIl3MVOjBKk4UhMStzM7blw23jBVeN-gjkzal8GswHQ" alt="Pago Móvil">
+                            </div>
                             <div class="payment-option-text">Pago Móvil</div>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- Display provided images for card, Zelle, Bitcoin, and Pago Móvil payment choices.
- Center payment icons and size images consistently.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c0546ae82c8324bb1dd8e754e19a62