### PR TITLE
Actualizar regalos y selección visual de transporte

### DIFF
--- a/pagos.css
+++ b/pagos.css
@@ -1378,6 +1378,12 @@
             color: #ffcc00;
         }
 
+        .gift-icon-display img {
+            max-width: 100%;
+            max-height: 100%;
+            object-fit: contain;
+        }
+
         .gift-card:hover .gift-icon-display {
             transform: scale(1.05);
         }
@@ -1526,71 +1532,39 @@
             color: var(--primary-color);
         }
 
-        /* Mejoras para compañías de envío */
-        .shipping-dropdown {
-            position: relative;
-            max-width: 40rem;
-            width: 100%;
+        /* Selección visual de compañías de envío */
+        .shipping-company-grid {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 2rem;
+            justify-content: center;
             margin-bottom: 3rem;
         }
 
-        .shipping-dropdown-btn {
-            width: 100%;
-            display: flex;
-            align-items: center;
-            justify-content: space-between;
-            padding: 1.5rem 2rem;
-            background-color: var(--white);
+        .shipping-company-card {
+            width: 14rem;
+            height: 9rem;
             border: 1px solid var(--border-color);
             border-radius: var(--radius);
-            font-size: 1.6rem;
-            font-weight: 500;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background-color: var(--white);
             cursor: pointer;
             transition: var(--transition);
             box-shadow: var(--shadow-sm);
+            padding: 1rem;
         }
 
-        .shipping-dropdown-btn:hover {
+        .shipping-company-card img {
+            max-width: 100%;
+            max-height: 100%;
+            object-fit: contain;
+        }
+
+        .shipping-company-card.selected {
             border-color: var(--primary-color);
             box-shadow: var(--shadow);
-        }
-
-        .shipping-dropdown-menu {
-            position: absolute;
-            top: calc(100% + 0.5rem);
-            left: 0;
-            width: 100%;
-            background-color: var(--white);
-            border: 1px solid var(--border-color);
-            border-radius: var(--radius);
-            box-shadow: var(--shadow-lg);
-            z-index: 100;
-            max-height: 30rem;
-            overflow-y: auto;
-            display: none;
-        }
-
-        .shipping-dropdown-menu.active {
-            display: block;
-        }
-
-        .shipping-company-option {
-            padding: 1.2rem 2rem;
-            cursor: pointer;
-            transition: var(--transition-fast);
-        }
-
-        .shipping-company-option:hover {
-            background-color: var(--primary-light);
-        }
-
-        .shipping-company-option.selected {
-            background-color: var(--primary-light);
-            font-weight: 600;
-        }
-
-        .shipping-company-text {
-            font-size: 1.6rem;
         }
 
         /* Seguro del equipo mejorado */
@@ -2927,7 +2901,7 @@
                 height: 7rem;
             }
 
-            .shipping-dropdown {
+            .shipping-company-grid {
                 max-width: 100%;
             }
 

--- a/pagos.html
+++ b/pagos.html
@@ -395,33 +395,24 @@
                 <div class="shipping-company" style="margin-top: 4rem;">
                     <h2 class="section-title"><i class="fas fa-building"></i> Selecciona la empresa de transporte</h2>
 
-                    <div class="shipping-dropdown">
-                        <button class="shipping-dropdown-btn" id="shipping-dropdown-btn">
-                            <span>Seleccionar empresa de transporte</span>
-                            <i class="fas fa-chevron-down"></i>
-                        </button>
-                        <div class="shipping-dropdown-menu" id="shipping-dropdown-menu">
-                            <div class="shipping-company-option" data-company="dhl">
-                                <div class="shipping-company-text">DHL</div>
-                            </div>
-                            <div class="shipping-company-option" data-company="fedex">
-                                <div class="shipping-company-text">FedEx</div>
-                            </div>
-                            <div class="shipping-company-option" data-company="zoom">
-                                <div class="shipping-company-text">ZOOM</div>
-                            </div>
-                            <div class="shipping-company-option" data-company="tealca">
-                                <div class="shipping-company-text">TEALCA</div>
-                            </div>
-                            <div class="shipping-company-option" data-company="mrw">
-                                <div class="shipping-company-text">MRW</div>
-                            </div>
-                            <div class="shipping-company-option" data-company="liberty">
-                                <div class="shipping-company-text">Liberty</div>
-                            </div>
-                            <div class="shipping-company-option" data-company="ipostel">
-                                <div class="shipping-company-text">Ipostel</div>
-                            </div>
+                    <div class="shipping-company-grid" id="shipping-company-container">
+                        <div class="shipping-company-card" data-company="dhl" data-name="DHL">
+                            <img src="https://www.logo.wine/a/logo/DHL/DHL-Logo.wine.svg" alt="DHL">
+                        </div>
+                        <div class="shipping-company-card" data-company="fedex" data-name="FedEx">
+                            <img src="https://www.logo.wine/a/logo/FedEx_Express/FedEx_Express-Logo.wine.svg" alt="FedEx">
+                        </div>
+                        <div class="shipping-company-card" data-company="zoom" data-name="ZOOM">
+                            <img src="https://upload.wikimedia.org/wikipedia/commons/7/71/Grupo_ZOOM_logo.png?20211116211646" alt="ZOOM">
+                        </div>
+                        <div class="shipping-company-card" data-company="tealca" data-name="TEALCA">
+                            <img src="https://www.tealca.es/wp-content/uploads/logo.png" alt="TEALCA">
+                        </div>
+                        <div class="shipping-company-card" data-company="mrw" data-name="MRW">
+                            <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/2/26/MRW_logo.svg/477px-MRW_logo.svg.png" alt="MRW">
+                        </div>
+                        <div class="shipping-company-card" data-company="liberty" data-name="Liberty Express">
+                            <img src="https://libertyexpress.com/wp-content/themes/kutis/assets/svg/logo_banner.svg" alt="Liberty Express">
                         </div>
                     </div>
 

--- a/pagos.js
+++ b/pagos.js
@@ -59,9 +59,7 @@
             const backToShippingBtn = document.getElementById('back-to-shipping');
             const processPaymentBtn = document.getElementById('process-payment');
             const shippingOptions = document.querySelectorAll('.shipping-option');
-            const shippingDropdownBtn = document.getElementById('shipping-dropdown-btn');
-            const shippingDropdownMenu = document.getElementById('shipping-dropdown-menu');
-            const shippingCompanyOptions = document.querySelectorAll('.shipping-company-option');
+            const shippingCompanyCards = document.querySelectorAll('.shipping-company-card');
             const insuranceOptions = document.querySelectorAll('.insurance-option');
             const acceptTaxCheckbox = document.getElementById('accept-tax');
             const taxInfo = document.getElementById('tax-info');
@@ -104,7 +102,7 @@
             const insuranceSummaryText = document.getElementById('insurance-summary-text');
             const changeInsuranceBtn = document.getElementById('change-insurance');
             const shippingOptionsContainer = document.querySelector('.shipping-options');
-            const shippingDropdownContainer = document.querySelector('.shipping-dropdown');
+            const shippingCompanyContainer = document.getElementById('shipping-company-container');
             const downloadInvoiceBtn = document.getElementById('download-invoice');
             const deliveryDateStart = document.getElementById('delivery-date-start');
             const deliveryDateStart2 = document.getElementById('delivery-date-start-2');
@@ -181,6 +179,7 @@
             let selectedBrand = '';
             let selectedShipping = { method: null, price: 0 };
             let selectedShippingCompany = null;
+            let selectedShippingCompanyName = '';
             let selectedInsurance = { selected: null, price: 0 };
             let selectedGift = null;
             let selectedPaymentMethod = null;
@@ -380,11 +379,11 @@
                         { id: 'airtag4pack', name: 'Airtag 4 Pack', price: 99, specs: ['Localización precisa', 'Batería reemplazable', 'Resistente al agua'] }
                     ],
                     samsung: [
-                        { id: 'samsungbuds3', name: 'Samsung Buds 3', price: 130, specs: ['Cancelación de ruido', 'Audio 360', 'Resistentes al agua'] },
-                        { id: 'samsungtag2', name: 'Samsung Tag 2', price: 30, specs: ['Localización precisa', 'Batería de larga duración', 'Resistente al agua'] }
+                        { id: 'samsungbuds3', name: 'Samsung Buds 3', price: 130, specs: ['Cancelación de ruido', 'Audio 360', 'Resistentes al agua'] }
                     ],
                     xiaomi: [
-                        { id: 'xiaomibuds5', name: 'Xiaomi Buds 5', price: 40, specs: ['Bluetooth 5.3', '40 horas de batería', 'Resistentes al agua'] }
+                        { id: 'xiaomibuds6pro', name: 'Xiaomi Buds 6 Pro', price: 40, specs: ['Bluetooth 5.3', 'Cancelación activa de ruido', 'Resistentes al agua'], image: 'https://thumb.pccomponentes.com/w-530-530/articles/1086/10866668/1452-xiaomi-redmi-buds-6-pro-auriculares-bluetooth-con-cancelacion-activa-de-ruido-espacio-negro.jpg' },
+                        { id: 'xiaomiwatch10', name: 'Smart Watch Xiaomi 10', price: 45, specs: ['Monitor de salud', 'Resistente al agua', 'Batería de larga duración'], image: 'https://m.media-amazon.com/images/I/71bRWtpGOAL.__AC_SX300_SY300_QL70_ML2_.jpg' }
                     ]
                 },
                 televisores: {
@@ -485,7 +484,8 @@
                                     name: product.name,
                                     price: product.price,
                                     category: categoryKey,
-                                    brand: brandKey
+                                    brand: brandKey,
+                                    image: product.image
                                 });
                             }
                         });
@@ -546,9 +546,10 @@
                     giftCard.setAttribute('data-id', product.id);
                     
                     const icon = defaultIcons[product.category] || 'fas fa-gift';
-                    
+                    const media = product.image ? `<img src="${product.image}" alt="${product.name}">` : `<i class="${icon}"></i>`;
+
                     giftCard.innerHTML = `
-                        <div class="gift-icon-display"><i class="${icon}"></i></div>
+                        <div class="gift-icon-display">${media}</div>
                         <div class="gift-info-card">
                             <div class="gift-name">${product.name}</div>
                             <div class="gift-free">Gratis</div>
@@ -1035,8 +1036,8 @@
                     shippingSummaryText.textContent = 'No seleccionado';
                 }
 
-                const companySelected = document.querySelector('.shipping-company-option.selected');
-                const companyText = companySelected ? companySelected.querySelector('.shipping-company-text').textContent.trim() : 'No seleccionado';
+                const companySelected = document.querySelector('.shipping-company-card.selected');
+                const companyText = companySelected ? companySelected.dataset.name : 'No seleccionado';
                 summaryCompany.textContent = `Empresa: ${companyText}`;
                 shippingCompanySummaryText.textContent = `Empresa de transporte: ${companyText}`;
 
@@ -1544,7 +1545,7 @@
                 }
                 
                 shippingMethod.textContent = shippingMethodText;
-                shippingCompanyElement.textContent = selectedShippingCompany.toUpperCase();
+                shippingCompanyElement.textContent = selectedShippingCompanyName.toUpperCase();
             }
 
             // Función para generar un código de promoción
@@ -1611,38 +1612,22 @@
                 e.target.value = value.substring(0, 4); // Limitar a 4 dígitos
             });
 
-            // Eventos para el dropdown de empresas de transporte
-            shippingDropdownBtn.addEventListener('click', function() {
-                shippingDropdownMenu.classList.toggle('active');
-            });
-
-            // Cerrar el dropdown al hacer clic fuera
-            document.addEventListener('click', function(e) {
-                if (!shippingDropdownBtn.contains(e.target) && !shippingDropdownMenu.contains(e.target)) {
-                    shippingDropdownMenu.classList.remove('active');
-                }
-            });
-
             // Seleccionar empresa de transporte
-            shippingCompanyOptions.forEach(option => {
-                option.addEventListener('click', function() {
+            shippingCompanyCards.forEach(card => {
+                card.addEventListener('click', function() {
                     // Remover selección previa
-                    shippingCompanyOptions.forEach(opt => opt.classList.remove('selected'));
+                    shippingCompanyCards.forEach(c => c.classList.remove('selected'));
 
                     // Seleccionar esta opción
-                    option.classList.add('selected');
+                    card.classList.add('selected');
 
                     // Actualizar empresa seleccionada
-                    selectedShippingCompany = option.getAttribute('data-company');
+                    selectedShippingCompany = card.getAttribute('data-company');
+                    selectedShippingCompanyName = card.dataset.name;
 
-                    // Actualizar texto del botón
-                    shippingDropdownBtn.querySelector('span').textContent = option.querySelector('.shipping-company-text').textContent;
-
-                    // Cerrar dropdown
-                    shippingDropdownMenu.classList.remove('active');
-                    shippingDropdownContainer.classList.add('hidden');
-                    const companyText = option.querySelector('.shipping-company-text').textContent;
-                    shippingCompanySummaryText.textContent = `Empresa de transporte: ${companyText}`;
+                    // Ocultar opciones y mostrar resumen
+                    shippingCompanyContainer.classList.add('hidden');
+                    shippingCompanySummaryText.textContent = `Empresa de transporte: ${selectedShippingCompanyName}`;
                     shippingCompanySummary.classList.remove('hidden');
 
                     // Actualizar resúmenes
@@ -1746,7 +1731,7 @@
                 if (!document.querySelector('.shipping-option.selected')) {
                     missing.push('el método de envío');
                 }
-                if (!document.querySelector('.shipping-company-option.selected')) {
+                if (!document.querySelector('.shipping-company-card.selected')) {
                     missing.push('la empresa de envío');
                 }
                 if (!document.querySelector('.insurance-option.selected')) {
@@ -1854,7 +1839,7 @@
 
             changeShippingCompanyBtn.addEventListener('click', () => {
                 shippingCompanySummary.classList.add('hidden');
-                shippingDropdownContainer.classList.remove('hidden');
+                shippingCompanyContainer.classList.remove('hidden');
             });
 
             changeInsuranceBtn.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- Reemplazar regalos: ahora se ofrecen Xiaomi Buds 6 Pro y Smart Watch Xiaomi 10 con imágenes.
- Implementar selección visual de empresas de transporte con tarjetas de logos.
- Ajustes de estilos y lógica para reflejar nuevas opciones de regalo y transporte.

## Testing
- `npm test` *(falla: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c0575e42d88324aef7ae33ef63abc7