### PR TITLE
Ask shipping location after selecting courier

### DIFF
--- a/pagos.css
+++ b/pagos.css
@@ -2352,6 +2352,52 @@
             width: 90%;
         }
 
+        /* Overlay de selección de ubicación */
+        .location-overlay {
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: rgba(0, 0, 0, 0.4);
+            display: none;
+            align-items: center;
+            justify-content: center;
+            z-index: var(--z-overlay);
+        }
+
+        .location-overlay.active {
+            display: flex;
+        }
+
+        .location-modal {
+            background: var(--white);
+            padding: 2rem;
+            border-radius: var(--radius);
+            box-shadow: var(--shadow-lg);
+            text-align: center;
+            max-width: 30rem;
+            width: 90%;
+        }
+
+        .location-modal label {
+            display: block;
+            margin-top: 1rem;
+            text-align: left;
+        }
+
+        .location-modal select {
+            width: 100%;
+            padding: 0.5rem;
+            margin-top: 0.5rem;
+            border: 1px solid #ccc;
+            border-radius: var(--radius);
+        }
+
+        .location-modal button {
+            margin-top: 1.5rem;
+        }
+
         /* Loading Overlay mejorado */
         .loading-overlay {
             position: fixed;

--- a/pagos.html
+++ b/pagos.html
@@ -908,6 +908,22 @@
         </div>
     </div>
 
+    <!-- Overlay de selección de ubicación -->
+    <div class="location-overlay" id="location-overlay">
+        <div class="location-modal">
+            <h3>¿Dónde está tu oficina?</h3>
+            <label for="location-state">Estado</label>
+            <select id="location-state">
+                <option value="">--Selecciona un estado--</option>
+            </select>
+            <label for="location-city">Ciudad</label>
+            <select id="location-city">
+                <option value="">--Selecciona una ciudad--</option>
+            </select>
+            <button class="btn btn-primary" id="location-confirm">Confirmar</button>
+        </div>
+    </div>
+
     <!-- Toast Notifications -->
     <div class="toast-container" id="toast-container">
         <!-- Toast notifications se agregarán aquí dinámicamente -->

--- a/pagos.js
+++ b/pagos.js
@@ -134,6 +134,82 @@
             const validationMessage = document.getElementById('validation-message');
             const validationClose = document.getElementById('validation-close');
 
+            const locationOverlay = document.getElementById('location-overlay');
+            const locationStateSelect = document.getElementById('location-state');
+            const locationCitySelect = document.getElementById('location-city');
+            const locationConfirm = document.getElementById('location-confirm');
+
+            const estadosCiudades = {
+                "Amazonas": ["Puerto Ayacucho", "San Fernando de Atabapo"],
+                "Anzoátegui": ["Barcelona", "Puerto La Cruz"],
+                "Apure": ["San Fernando de Apure", "Guasdualito"],
+                "Aragua": ["Maracay", "Turmero"],
+                "Barinas": ["Barinas", "Socopó"],
+                "Bolívar": ["Ciudad Bolívar", "Ciudad Guayana"],
+                "Carabobo": ["Valencia", "Puerto Cabello"],
+                "Cojedes": ["San Carlos", "Tinaquillo"],
+                "Delta Amacuro": ["Tucupita", "San José de Amacuro"],
+                "Falcón": ["Coro", "Punto Fijo"],
+                "Guárico": ["San Juan de los Morros", "Calabozo"],
+                "Lara": ["Barquisimeto", "Carora"],
+                "Mérida": ["Mérida", "El Vigía"],
+                "Miranda": ["Los Teques", "Guatire"],
+                "Monagas": ["Maturín", "Punta de Mata"],
+                "Nueva Esparta": ["La Asunción", "Porlamar"],
+                "Portuguesa": ["Guanare", "Acarigua"],
+                "Sucre": ["Cumaná", "Carúpano"],
+                "Táchira": ["San Cristóbal", "Táriba"],
+                "Trujillo": ["Trujillo", "Valera"],
+                "La Guaira": ["La Guaira", "Maiquetía"],
+                "Yaracuy": ["San Felipe", "Yaritagua"],
+                "Zulia": ["Maracaibo", "Cabimas"]
+            };
+
+            function populateStates() {
+                if (!locationStateSelect) return;
+                locationStateSelect.innerHTML = '<option value="">--Selecciona un estado--</option>';
+                Object.keys(estadosCiudades).forEach(estado => {
+                    const option = document.createElement('option');
+                    option.value = estado;
+                    option.textContent = estado;
+                    locationStateSelect.appendChild(option);
+                });
+                locationCitySelect.innerHTML = '<option value="">--Selecciona una ciudad--</option>';
+            }
+
+            function populateCities() {
+                const estado = locationStateSelect.value;
+                locationCitySelect.innerHTML = '<option value="">--Selecciona una ciudad--</option>';
+                if (estado && estadosCiudades[estado]) {
+                    estadosCiudades[estado].forEach(ciudad => {
+                        const option = document.createElement('option');
+                        option.value = ciudad;
+                        option.textContent = ciudad;
+                        locationCitySelect.appendChild(option);
+                    });
+                }
+            }
+
+            if (locationStateSelect) {
+                locationStateSelect.addEventListener('change', populateCities);
+            }
+
+            if (locationConfirm) {
+                locationConfirm.addEventListener('click', () => {
+                    stateInput.value = locationStateSelect.value;
+                    cityInput.value = locationCitySelect.value;
+                    locationOverlay.classList.remove('active');
+                });
+            }
+
+            if (locationOverlay) {
+                locationOverlay.addEventListener('click', (e) => {
+                    if (e.target === locationOverlay) {
+                        locationOverlay.classList.remove('active');
+                    }
+                });
+            }
+
             const sendDeliveryInfoBtn = document.getElementById('send-delivery-info');
             const fullNameInput = document.getElementById('full-name');
             const idNumberInput = document.getElementById('id-number');
@@ -1666,6 +1742,10 @@
 
                     // Notificar al usuario
                     showToast('info', 'Transportista seleccionado', `Has elegido ${selectedShippingCompany.toUpperCase()} como empresa de transporte.`);
+
+                    // Mostrar overlay para selección de estado y ciudad
+                    populateStates();
+                    locationOverlay.classList.add('active');
                 });
             });
 


### PR DESCRIPTION
## Summary
- add overlay to prompt Venezuelan state and city after picking a shipping company
- style new overlay and inputs
- load state/city options and populate address fields via JS

## Testing
- `npm test` *(fails: enoent Could not read package.json)*
- `node --check pagos.js`


------
https://chatgpt.com/codex/tasks/task_e_68c0605a90f0832489a1d14224f8b807