### PR TITLE
Add new Samsung tablets and watches

### DIFF
--- a/index.html
+++ b/index.html
@@ -1682,6 +1682,20 @@
                             <td class="product-price-bs">82.800,00 Bs</td>
                             <td class="buy-cell"><a href="pagos.html" class="buy-btn">Comprar</a></td>
                         </tr>
+                        <tr>
+                            <td class="product-name">Samsung Tab S11</td>
+                            <td>X910 12/256GB</td>
+                            <td class="product-price">$1,000</td>
+                            <td class="product-price-bs">90.000,00 Bs</td>
+                            <td class="buy-cell"><a href="pagos.html" class="buy-btn">Comprar</a></td>
+                        </tr>
+                        <tr>
+                            <td class="product-name">Samsung Tab S11 Ultra</td>
+                            <td>X916 16/512GB</td>
+                            <td class="product-price">$1,200</td>
+                            <td class="product-price-bs">108.000,00 Bs</td>
+                            <td class="buy-cell"><a href="pagos.html" class="buy-btn">Comprar</a></td>
+                        </tr>
                     </tbody>
                 </table>
                 
@@ -1771,6 +1785,20 @@
                             <td>47MM</td>
                             <td class="product-price">$390</td>
                             <td class="product-price-bs">35.100,00 Bs</td>
+                            <td class="buy-cell"><a href="pagos.html" class="buy-btn">Comprar</a></td>
+                        </tr>
+                        <tr>
+                            <td class="product-name">Samsung Watch 8</td>
+                            <td>44MM</td>
+                            <td class="product-price">$260</td>
+                            <td class="product-price-bs">23.400,00 Bs</td>
+                            <td class="buy-cell"><a href="pagos.html" class="buy-btn">Comprar</a></td>
+                        </tr>
+                        <tr>
+                            <td class="product-name">Samsung Watch 8 Classic</td>
+                            <td>47MM</td>
+                            <td class="product-price">$310</td>
+                            <td class="product-price-bs">27.900,00 Bs</td>
                             <td class="buy-cell"><a href="pagos.html" class="buy-btn">Comprar</a></td>
                         </tr>
                     </tbody>

--- a/pagos.html
+++ b/pagos.html
@@ -135,7 +135,7 @@
                     </video>
                     <div class="featured-overlay fade-in">
                         <h3>Nueva colección Galaxy 2025</h3>
-                        <p>Descubre la última tecnología Samsung con la mejor experiencia en fotografía, batería y rendimiento.</p>
+                        <p>Descubre la última tecnología Samsung con los nuevos Galaxy Tab S11, Tab S11 Ultra, Watch 8 y Watch 8 Classic.</p>
                     </div>
                 </div>
 

--- a/pagos.js
+++ b/pagos.js
@@ -435,7 +435,9 @@
                     ],
                     samsung: [
                         { id: 'samsungtaba9', name: 'Samsung Tab A9 X110 4/64GB', price: 125, specs: ['4GB RAM', '64GB', 'Pantalla 8.7"'] },
-                        { id: 'samsungtabs10', name: 'Samsung Tab S10 Plus X820 12/256GB', price: 880, specs: ['12GB RAM', '256GB', 'Pantalla 12.4"'] }
+                        { id: 'samsungtabs10', name: 'Samsung Tab S10 Plus X820 12/256GB', price: 880, specs: ['12GB RAM', '256GB', 'Pantalla 12.4"'] },
+                        { id: 'samsungtabs11', name: 'Samsung Tab S11 X910 12/256GB', price: 1000, specs: ['12GB RAM', '256GB', 'Pantalla 11"'] },
+                        { id: 'samsungtabs11ultra', name: 'Samsung Tab S11 Ultra X916 16/512GB', price: 1200, specs: ['16GB RAM', '512GB', 'Pantalla 14.6"'] }
                     ],
                     xiaomi: [
                         { id: 'xiaomipad6', name: 'Xiaomi Pad 6 6GB/128GB', price: 310, specs: ['6GB RAM', '128GB', 'Snapdragon 870'] }
@@ -449,7 +451,9 @@
                     ],
                     samsung: [
                         { id: 'samsungwatch7', name: 'Samsung Watch 7 44MM', price: 230, specs: ['Pantalla 44mm', 'Wear OS', 'BioActive Sensor'] },
-                        { id: 'samsungwatchultra', name: 'Samsung Watch Ultra 47MM', price: 390, specs: ['Pantalla 47mm', 'Titanio', 'GPS + LTE'] }
+                        { id: 'samsungwatchultra', name: 'Samsung Watch Ultra 47MM', price: 390, specs: ['Pantalla 47mm', 'Titanio', 'GPS + LTE'] },
+                        { id: 'samsungwatch8', name: 'Samsung Watch 8 44MM', price: 260, specs: ['Pantalla 44mm', 'Wear OS', 'BioActive Sensor'] },
+                        { id: 'samsungwatch8classic', name: 'Samsung Watch 8 Classic 47MM', price: 310, specs: ['Pantalla 47mm', 'Acero inoxidable', 'GPS + LTE'] }
                     ],
                     xiaomi: [
                         { id: 'xiaomiwatch4', name: 'Xiaomi Watch 4', price: 99, specs: ['Pantalla AMOLED', 'Wear OS', '30 días batería'] }


### PR DESCRIPTION
## Summary
- Add Samsung Tab S11 and Tab S11 Ultra to tablets catalog
- Add Samsung Watch 8 and Watch 8 Classic to smartwatches
- Expand payment page inventory and highlight new Samsung lineup

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c0774937848324913b65ecc5943ebc