### PR TITLE
Mostrar logo de marca en pagos y actualizar sellos

### DIFF
--- a/pagos.html
+++ b/pagos.html
@@ -88,12 +88,7 @@
             <p class="checkout-subtitle">Completa tu pedido de forma rápida y segura para recibir los mejores equipos tecnológicos de Latinoamérica</p>
         </header>
 
-        <div class="brand-logo-strip" style="display:flex;gap:20px;justify-content:center;align-items:center;flex-wrap:wrap;margin:20px 0;">
-            <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/2/2a/Logo_of_the_TCL_Corporation.svg/960px-Logo_of_the_TCL_Corporation.svg.png" alt="TCL" style="height:40px;">
-            <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/9/95/Nintendo_Logo_2017.png/960px-Nintendo_Logo_2017.png" alt="Nintendo" style="height:40px;">
-            <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/9/96/Microsoft_logo_%282012%29.svg/512px-Microsoft_logo_%282012%29.svg.png" alt="Microsoft" style="height:40px;">
-            <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/a/ad/HP_logo_2012.svg/100px-HP_logo_2012.svg.png" alt="HP" style="height:40px;">
-        </div>
+        <div id="brand-logo-strip" class="brand-logo-strip" style="display:none;gap:20px;justify-content:center;align-items:center;flex-wrap:wrap;margin:20px 0;"></div>
 
         <!-- Pasos del proceso de pago mejorados -->
         <nav class="checkout-steps fade-in">
@@ -837,8 +832,8 @@
             </div>
         </main>
         <section class="trust-seals">
-            <img src="https://www.confianzaonline.es/empresas/sellos/sello.png" alt="Confianza Online">
-            <img src="https://secure.comodo.com/trustlogo/images/comodo_secure_seal_113x59_white.png" alt="SSL Comodo">
+            <img src="https://images.seeklogo.com/logo-png/20/1/norton-by-symantec-logo-png_seeklogo-201265.png" alt="Confianza Online">
+            <img src="https://www.clipartmax.com/png/small/205-2051305_comodo-trusted-site-seal-ssl-secure-logo-png.png" alt="SSL Comodo">
         </section>
     </div>
 

--- a/pagos.js
+++ b/pagos.js
@@ -38,6 +38,7 @@
             const categoryCards = document.querySelectorAll('.category-card');
             const brandSelection = document.querySelector('.brand-selection');
             const brandGrid = document.querySelector('#brand-grid');
+            const brandLogoStrip = document.getElementById('brand-logo-strip');
             const productGrid = document.querySelector('#product-grid');
             const cartSection = document.querySelector('.cart-section');
             const stepCountry = document.getElementById('step-country');
@@ -716,6 +717,10 @@
 
             // Función para seleccionar una categoría
             function selectCategory(category) {
+                if (brandLogoStrip) {
+                    brandLogoStrip.style.display = 'none';
+                    brandLogoStrip.innerHTML = '';
+                }
                 // Eliminar la selección actual
                 categoryCards.forEach(card => {
                     card.classList.remove('selected');
@@ -772,7 +777,19 @@
                         // Seleccionar esta marca
                         brandCard.classList.add('selected');
                         selectedBrand = brand;
-                        
+
+                        // Mostrar logo de la marca seleccionada
+                        if (brandLogoStrip) {
+                            const logoSrc = brandLogos[brand];
+                            if (logoSrc) {
+                                brandLogoStrip.innerHTML = `<img src="${logoSrc}" alt="${brand}">`;
+                                brandLogoStrip.style.display = 'flex';
+                            } else {
+                                brandLogoStrip.style.display = 'none';
+                                brandLogoStrip.innerHTML = '';
+                            }
+                        }
+
                         // Renderizar los productos de esta marca
                         renderProducts(category, brand);
 
@@ -1813,17 +1830,29 @@
                 stepCountry.style.display = 'block';
                 productSelection.style.display = 'none';
                 backToCountryBtn.style.display = 'none';
+                if (brandLogoStrip) {
+                    brandLogoStrip.style.display = 'none';
+                    brandLogoStrip.innerHTML = '';
+                }
             });
 
             backToCategoryBtn.addEventListener('click', () => {
                 brandSelection.style.display = 'none';
                 stepCategory.style.display = 'block';
                 stepProduct.style.display = 'none';
+                if (brandLogoStrip) {
+                    brandLogoStrip.style.display = 'none';
+                    brandLogoStrip.innerHTML = '';
+                }
             });
 
             backToBrandBtn.addEventListener('click', () => {
                 stepProduct.style.display = 'none';
                 brandSelection.style.display = 'block';
+                if (brandLogoStrip) {
+                    brandLogoStrip.style.display = 'none';
+                    brandLogoStrip.innerHTML = '';
+                }
             });
 
             // 3. Botones de navegación entre pasos


### PR DESCRIPTION
## Summary
- Muestra solo el logo de la marca elegida en la pasarela de pago en lugar de todos los logos a la vez.
- Actualiza las imágenes de los sellos de Confianza Online y SSL Comodo por las nuevas URLs proporcionadas.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c07f2184b0832487c46dc027ccdd8b