### PR TITLE
Destacar opciones recomendadas y nuevas ciudades en pagos

### DIFF
--- a/pagos.css
+++ b/pagos.css
@@ -1473,6 +1473,18 @@
             overflow: hidden;
         }
 
+        .recommended-badge {
+            position: absolute;
+            top: 0.8rem;
+            right: 0.8rem;
+            background: var(--secondary-color);
+            color: var(--white);
+            padding: 0.2rem 0.6rem;
+            border-radius: var(--radius-sm);
+            font-size: 1.2rem;
+            font-weight: 600;
+        }
+
         .shipping-option::before {
             content: '';
             position: absolute;
@@ -1585,6 +1597,7 @@
             transition: var(--transition);
             box-shadow: var(--shadow-sm);
             padding: 1rem;
+            position: relative;
         }
 
         .shipping-company-card img {
@@ -1658,6 +1671,10 @@
         .insurance-info {
             flex-grow: 1;
             min-width: 0;
+            text-align: center;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
         }
 
         .insurance-title {
@@ -1666,9 +1683,11 @@
             margin-bottom: 0.8rem;
             display: flex;
             align-items: center;
+            justify-content: center;
             gap: 1rem;
             color: var(--secondary-color);
             line-height: 1.3;
+            text-align: center;
         }
 
         .insurance-logo {
@@ -1680,6 +1699,7 @@
             font-size: 1.4rem;
             color: var(--accent-color);
             line-height: 1.4;
+            text-align: center;
         }
 
         .insurance-price {

--- a/pagos.html
+++ b/pagos.html
@@ -372,6 +372,7 @@
 
                 <div class="shipping-options">
                     <div class="shipping-option" data-shipping="express" data-price="70">
+                        <div class="recommended-badge">Recomendado</div>
                         <div class="shipping-radio"></div>
                         <div class="shipping-info">
                             <div class="shipping-title">
@@ -425,6 +426,7 @@
                             <img src="https://www.tealca.es/wp-content/uploads/logo.png" alt="TEALCA">
                         </div>
                         <div class="shipping-company-card" data-company="mrw" data-name="MRW">
+                            <div class="recommended-badge">Recomendado</div>
                             <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/2/26/MRW_logo.svg/477px-MRW_logo.svg.png" alt="MRW">
                         </div>
                         <div class="shipping-company-card" data-company="liberty" data-name="Liberty Express">
@@ -464,6 +466,7 @@
                         <div class="insurance-price">$50.00</div>
                     </div>
                     <div class="insurance-option premium" data-insurance="true" data-provider="Mercantil" data-price="50">
+                        <div class="recommended-badge">Recomendado</div>
                         <div class="shipping-radio"></div>
                         <div class="insurance-info">
                             <div class="insurance-title">

--- a/pagos.js
+++ b/pagos.js
@@ -163,7 +163,8 @@
                 "Trujillo": ["Trujillo", "Valera"],
                 "La Guaira": ["La Guaira", "Maiquetía"],
                 "Yaracuy": ["San Felipe", "Yaritagua"],
-                "Zulia": ["Maracaibo", "Cabimas"]
+                "Zulia": ["Maracaibo", "Cabimas"],
+                "Distrito Capital": ["Caracas-Centro", "Altamira-Chacao"]
             };
 
             function populateStates() {


### PR DESCRIPTION
## Summary
- Añade insignias de "Recomendado" para el envío Express, la empresa MRW y el seguro Mercantil
- Centra la información en las opciones de seguro
- Incluye Distrito Capital con Caracas-Centro y Altamira-Chacao en el selector de ciudades

## Testing
- `npm test` *(falla: no se encontró package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c080ec8c2083248025a2f8da77ba12