### PR TITLE
Fix nationalization fee when cart is empty

### DIFF
--- a/pagos.js
+++ b/pagos.js
@@ -1096,14 +1096,19 @@
 
             // Función para calcular la tasa de nacionalización con la lógica requerida
             function calculateNationalizationFee(totalUSD) {
+                // Si no hay productos en el carrito, no se cobra tasa
+                if (totalUSD <= 0) {
+                    return 0;
+                }
+
                 // Calcular primero el 2% estándar en Bs
                 let standardFee = totalUSD * 0.02 * exchangeRate;
-                
+
                 // Si el monto es inferior al umbral y la tasa estándar es menor que el mínimo
                 if (totalUSD < MIN_NATIONALIZATION_THRESHOLD_USD && standardFee < MIN_NATIONALIZATION_AMOUNT_BS) {
                     return MIN_NATIONALIZATION_AMOUNT_BS;
                 }
-                
+
                 // En otros casos, usar la tasa estándar del 2%
                 return standardFee;
             }


### PR DESCRIPTION
## Summary
- Ensure the nationalization fee displays 0 Bs when the cart is empty instead of a minimum charge

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c0822a9c348324bb919d1efae671fd