### PR TITLE
Allow cart checkout button to open shipping step

### DIFF
--- a/pagos.html
+++ b/pagos.html
@@ -1113,8 +1113,9 @@
                 if (goToCheckoutBtn) {
                     goToCheckoutBtn.addEventListener('click', () => {
                         cartModal.classList.remove('show');
-                        const step2 = document.querySelector('.checkout-step[data-step="2"]');
-                        if (step2) step2.click();
+                        if (window.goToStep) {
+                            window.goToStep(2);
+                        }
                         const section2 = document.getElementById('section-2');
                         if (section2) section2.scrollIntoView({ behavior: 'smooth' });
                     });

--- a/pagos.js
+++ b/pagos.js
@@ -1325,6 +1325,9 @@
                 });
             }
 
+            // Exponer la función para que otros scripts puedan cambiar de paso
+            window.goToStep = goToStep;
+
             // Validar información de la tarjeta
             function validateCardInfo() {
                 const cardName = cardNameInput.value.trim();


### PR DESCRIPTION
## Summary
- Expose `goToStep` globally so other scripts can change checkout steps
- Make "Ir a pagar" button jump directly to the Envío step and scroll to that section

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/latinstore/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68c085f6de4c83248085d274a7b548d7