### PR TITLE
Mostrar logo de envío y color de equipos en páginas de cuenta

### DIFF
--- a/micuenta.html
+++ b/micuenta.html
@@ -272,6 +272,15 @@
     const todayISO = () => new Date().toISOString().slice(0,10);
     const uid = (p='ID') => p + Math.random().toString(36).slice(2,9).toUpperCase();
 
+    const courierInfo = {
+      dhl: {name:'DHL',logo:'https://www.logo.wine/a/logo/DHL/DHL-Logo.wine.svg'},
+      fedex: {name:'FedEx',logo:'https://www.logo.wine/a/logo/FedEx_Express/FedEx_Express-Logo.wine.svg'},
+      zoom: {name:'ZOOM',logo:'https://upload.wikimedia.org/wikipedia/commons/7/71/Grupo_ZOOM_logo.png?20211116211646'},
+      tealca: {name:'TEALCA',logo:'https://www.tealca.es/wp-content/uploads/logo.png'},
+      mrw: {name:'MRW',logo:'https://upload.wikimedia.org/wikipedia/commons/2/26/MRW_logo.svg'},
+      liberty: {name:'Liberty Express',logo:'https://libertyexpress.com/wp-content/themes/kutis/assets/svg/logo_banner.svg'}
+    };
+
     function saveLS(key, val){ localStorage.setItem(key, JSON.stringify(val)); }
     function getLS(key, fallback){
       try{ return JSON.parse(localStorage.getItem(key)) ?? fallback; }catch(e){ return fallback; }
@@ -471,13 +480,17 @@
 
       orders.forEach(o=>{
         const steps = o.shipping?.steps || [];
-        const progress = Math.min(100, Math.round((steps.length / 5) * 100)); // escala simple
+        const progress = Math.min(100, Math.round((steps.length / 5) * 100));
+        const courier = courierInfo[o.shipping?.courier] || {};
+        const address = getLS('lpAddresses', [])[0] || {};
         root.insertAdjacentHTML('beforeend', `
           <div class="card">
             <div style="display:flex;gap:10px;justify-content:space-between;align-items:center;flex-wrap:wrap">
               <div>
-                <strong>${o.id}</strong> · <span class="muted">${o.shipping?.courier || 'Courier'}</span><br>
-                <span class="muted">Tracking: ${o.shipping?.tracking || '-'}</span>
+                <strong>${o.id}</strong><br>
+                <span class="muted">${courier.logo ? `<img src="${courier.logo}" alt="${courier.name}" style="height:16px;vertical-align:middle;margin-right:4px;">${courier.name}` : (o.shipping?.courier || 'Courier')}</span><br>
+                <span class="muted">Tracking: ${o.shipping?.tracking || '-'}</span><br>
+                <span class="muted">${address.city || '-'}, ${address.region || '-'}</span>
               </div>
               <div style="min-width:220px">
                 <div class="progress"><span style="width:${progress}%"></span></div>
@@ -851,6 +864,8 @@
     function openOrder(id){
       const o = getLS('lpOrders', []).find(x=>x.id===id);
       if(!o) return;
+      const courier = courierInfo[o.shipping?.courier] || {};
+      const address = getLS('lpAddresses', [])[0] || {};
       const el = $('#modalOrderBody');
       el.innerHTML = `
         <div style="display:flex;gap:10px;justify-content:space-between;align-items:center;flex-wrap:wrap">
@@ -860,11 +875,12 @@
         <div class="hr"></div>
         <h4>Artículos</h4>
         <table class="table">
-          <thead><tr><th>Producto</th><th>Cant.</th><th>Precio</th><th>Subtotal</th></tr></thead>
+          <thead><tr><th>Producto</th><th>Color</th><th>Cant.</th><th>Precio</th><th>Subtotal</th></tr></thead>
           <tbody>
             ${o.items.map(it=>`
               <tr>
                 <td>${it.name} <span class="muted">(${it.sku})</span></td>
+                <td>${it.color || '-'}</td>
                 <td>${it.qty}</td>
                 <td>${fmt.format(it.price)}</td>
                 <td>${fmt.format(it.price*it.qty)}</td>
@@ -874,7 +890,9 @@
         </table>
         <div class="hr"></div>
         <h4>Envío</h4>
-        <div class="muted">Courier: ${o.shipping?.courier || '-'}</div>
+        <div class="muted">Courier: ${courier.logo ? `<img src="${courier.logo}" alt="${courier.name}" style="height:20px;vertical-align:middle;margin-right:4px;">${courier.name}` : (o.shipping?.courier || '-')}</div>
+        <div class="muted">Estado: ${address.region || '-'}</div>
+        <div class="muted">Ciudad: ${address.city || '-'}</div>
         <div class="muted">Tracking: ${o.shipping?.tracking || '-'}</div>
         <div class="muted">ETA: ${o.shipping?.eta || '-'}</div>
         <div class="timeline" style="margin-top:10px">

--- a/winderavellaneda.html
+++ b/winderavellaneda.html
@@ -451,8 +451,8 @@
         </div>
       </div>
       <div class="meta">
-        <b>N° de Orden: LP-X9D8NVWE</b>
-        <span>Fecha: 07/09/2025</span>
+        <b>N° de Orden: <span id="orderId"></span></b>
+        <span>Fecha: <span id="orderDate"></span></span>
       </div>
     </header>
 
@@ -481,12 +481,12 @@
     <section class="section grid" aria-label="Datos de cliente y entrega">
       <div class="card">
         <h3>Facturación (Cliente)</h3>
-        <div class="kv"><b>Nombre</b><span>Winder Manuel Fernández Avellaneda</span></div>
-        <div class="kv"><b>Documento</b><span>V-30.966.019</span></div>
-        <div class="kv"><b>Teléfono</b><span>+58 0412-6783725</span></div>
-        <div class="kv"><b>Dirección</b><span>Av. Circunvalación Sur, Barrio Simón Bolívar, Casa N° 350</span></div>
-        <div class="kv"><b>Estado</b><span>Portuguesa</span></div>
-        <div class="kv"><b>Ciudad</b><span>Acarigua</span></div>
+        <div class="kv"><b>Nombre</b><span id="custName"></span></div>
+        <div class="kv"><b>Documento</b><span id="custDoc"></span></div>
+        <div class="kv"><b>Teléfono</b><span id="custPhone"></span></div>
+        <div class="kv"><b>Dirección</b><span id="custAddress"></span></div>
+        <div class="kv"><b>Estado</b><span id="custState"></span></div>
+        <div class="kv"><b>Ciudad</b><span id="custCity"></span></div>
 
         <div class="idbox">
             <span class="pill">Documento de identidad adjunto</span>
@@ -496,12 +496,10 @@
       <div class="card">
         <h3>Entrega / Transporte</h3>
         <div class="carrier">
-          <b>Empresa:</b> <img src="https://libertyexpress.com/wp-content/themes/kutis/assets/svg/logo_banner.svg" alt="Liberty Express">
+          <b>Empresa:</b> <img id="courierLogo" alt="" style="height:24px;"> <span id="courierName"></span>
         </div>
-        <div class="kv"><b>Modalidad</b><span>Retiro en sucursal</span></div>
-        <div class="kv"><b>Sucursal</b>
-          <span>Liberty Express – C.C. Rupica, Local N° 03, PB, Acarigua, Venezuela</span>
-        </div>
+        <div class="kv"><b>Estado</b><span id="shipState"></span></div>
+        <div class="kv"><b>Ciudad</b><span id="shipCity"></span></div>
         
         <div class="timeline" aria-label="Línea de tiempo de entrega">
           <div class="step done">
@@ -541,47 +539,22 @@
               <th class="right">Importe (USD)</th>
             </tr>
           </thead>
-          <tbody>
-            <tr>
-              <td>iPhone 13 128GB — <i>Blanco estelar</i><br><span class="muted-text">IMEI 1: 356789104582631</span></td>
-              <td class="right">1</td>
-              <td class="right">$560.00</td>
-              <td class="right">$560.00</td>
-            </tr>
-            <tr>
-              <td>iPhone 14 128GB — <i>Blanco estelar</i><br><span class="muted-text">IMEI 2: 490154203237518</span></td>
-              <td class="right">1</td>
-              <td class="right">$650.00</td>
-              <td class="right">$650.00</td>
-            </tr>
-            <tr>
-              <td>Samsung Tag 2 <span class="gift">— Regalo GRATIS</span></td>
-              <td class="right">1</td>
-              <td class="right">$0.00</td>
-              <td class="right">$0.00</td>
-            </tr>
-            <tr>
-              <td>Xiaomi Buds 5 <span class="gift">— Regalo EXTRA</span></td>
-              <td class="right">1</td>
-              <td class="right">$0.00</td>
-              <td class="right">$0.00</td>
-            </tr>
-          </tbody>
+          <tbody id="productsBody"></tbody>
           </table>
         </div>
 
         <div class="total-summary" aria-label="Resumen de totales">
-          <div class="row"><span>Subtotal</span><b>$1,210.00</b></div>
-          <div class="row"><span>IVA (16%)</span><b>$193.60</b></div>
-          <div class="row"><span>Envío — Express (1–4 días)</span><b>$35.00</b></div>
-          <div class="row grand"><span>Total USD</span><span>$1,438.60</span></div>
+          <div class="row"><span>Subtotal</span><b id="subtotalUSD"></b></div>
+          <div class="row"><span>IVA (16%)</span><b id="taxUSD"></b></div>
+          <div class="row"><span>Envío</span><b id="shippingUSD"></b></div>
+          <div class="row grand"><span>Total USD</span><span id="totalUSD"></span></div>
           <div class="row"><span class="badge success">Tasa de nacionalización</span><b class="badge success">Pagada</b></div>
         </div>
         
         <div style="margin-top:20px;display:flex;gap:12px;flex-wrap:wrap">
             <div class="pill">Pago: Tarjeta</div>
-            <div class="pill">Transporte: LIBERTY</div>
-            <div class="pill">Estado: <span class="badge success">En preparación</span></div>
+            <div class="pill">Transporte: <span id="courierPill"></span></div>
+            <div class="pill">Estado: <span id="statusPill" class="badge success"></span></div>
         </div>
 
       </div>
@@ -608,7 +581,7 @@
 
     <footer>
       <div>LatinPhone © 2025 — Comprobante válido con número de orden.</div>
-      <div>Generado: 07/09/2025 • Orden: LP-X9D8NVWE</div>
+      <div>Generado: <span id="orderDateFooter"></span> • Orden: <span id="orderIdFooter"></span></div>
     </footer>
   </article>
 
@@ -626,7 +599,54 @@
   (function(){
     const overlay = document.getElementById('alertOverlay');
     const closeBtn = document.getElementById('alertClose');
-    closeBtn.addEventListener('click', ()=> overlay.style.display='none');
+    if(closeBtn) closeBtn.addEventListener('click', ()=> overlay.style.display='none');
+
+    const courierInfo = {
+      dhl:{name:'DHL',logo:'https://www.logo.wine/a/logo/DHL/DHL-Logo.wine.svg'},
+      fedex:{name:'FedEx',logo:'https://www.logo.wine/a/logo/FedEx_Express/FedEx_Express-Logo.wine.svg'},
+      zoom:{name:'ZOOM',logo:'https://upload.wikimedia.org/wikipedia/commons/7/71/Grupo_ZOOM_logo.png?20211116211646'},
+      tealca:{name:'TEALCA',logo:'https://www.tealca.es/wp-content/uploads/logo.png'},
+      mrw:{name:'MRW',logo:'https://upload.wikimedia.org/wikipedia/commons/2/26/MRW_logo.svg'},
+      liberty:{name:'Liberty Express',logo:'https://libertyexpress.com/wp-content/themes/kutis/assets/svg/logo_banner.svg'}
+    };
+
+    const orders = JSON.parse(localStorage.getItem('lpOrders')||'[]');
+    if(!orders.length) return;
+    const order = orders[orders.length-1];
+    const user = JSON.parse(localStorage.getItem('lpUser')||'{}');
+    const address = (JSON.parse(localStorage.getItem('lpAddresses')||'[]'))[0]||{};
+    const totals = JSON.parse(localStorage.getItem('latinphone_cart_totals')||'{}');
+    const courier = courierInfo[order.shipping?.courier] || {name: order.shipping?.courier || '', logo:''};
+
+    document.getElementById('orderId').textContent = order.id;
+    document.getElementById('orderDate').textContent = order.date;
+    document.getElementById('orderIdFooter').textContent = order.id;
+    document.getElementById('orderDateFooter').textContent = order.date;
+    document.getElementById('custName').textContent = user.name || '';
+    document.getElementById('custDoc').textContent = user.doc || '';
+    document.getElementById('custPhone').textContent = user.phone || '';
+    document.getElementById('custAddress').textContent = address.line1 || '';
+    document.getElementById('custState').textContent = address.region || '';
+    document.getElementById('custCity').textContent = address.city || '';
+    document.getElementById('shipState').textContent = address.region || '';
+    document.getElementById('shipCity').textContent = address.city || '';
+    document.getElementById('courierLogo').src = courier.logo;
+    document.getElementById('courierLogo').alt = courier.name;
+    document.getElementById('courierName').textContent = courier.name;
+    document.getElementById('courierPill').textContent = courier.name.toUpperCase();
+    document.getElementById('statusPill').textContent = order.status;
+
+    const tbody = document.getElementById('productsBody');
+    order.items.forEach(it=>{
+      const tr = document.createElement('tr');
+      tr.innerHTML = `<td>${it.name} — <i>${it.color||''}</i></td><td class="right">${it.qty}</td><td class="right">$${it.price.toFixed(2)}</td><td class="right">$${(it.price*it.qty).toFixed(2)}</td>`;
+      tbody.appendChild(tr);
+    });
+
+    document.getElementById('subtotalUSD').textContent = `$${(totals.subtotal||0).toFixed(2)}`;
+    document.getElementById('taxUSD').textContent = `$${(totals.tax||0).toFixed(2)}`;
+    document.getElementById('shippingUSD').textContent = `$${(totals.shipping||0).toFixed(2)}`;
+    document.getElementById('totalUSD').textContent = `$${(totals.total||0).toFixed(2)}`;
   })();
   </script>
 </body>


### PR DESCRIPTION
## Summary
- Recupera logos de empresas de transporte y muestra ciudad y estado en la vista de seguimiento y detalle de pedidos
- Incluye color del equipo en los detalles del pedido
- Genera factura dinámica con datos guardados en localStorage: logo del courier, dirección, colores y totales

## Testing
- `npm test` *(falla: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c0931db8a48324a406615e47cb013a