### PR TITLE
Add full-screen pages for Winder Avellaneda images

### DIFF
--- a/30966019.html
+++ b/30966019.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>30966019</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        html, body {
+            height: 100%;
+            width: 100%;
+        }
+        img {
+            display: block;
+            width: 100vw;
+            height: 100vh;
+            object-fit: cover;
+        }
+    </style>
+</head>
+<body>
+    <img src="winderavellaneda1.jpg" alt="Winder Avellaneda 1" />
+    <img src="winderavellaneda2.jpg" alt="Winder Avellaneda 2" />
+</body>
+</html>

--- a/winderavellaneda.html
+++ b/winderavellaneda.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Winder Avellaneda</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        html, body {
+            height: 100%;
+            width: 100%;
+        }
+        img {
+            display: block;
+            width: 100vw;
+            height: 100vh;
+            object-fit: cover;
+        }
+    </style>
+</head>
+<body>
+    <img src="winderavellaneda1.jpg" alt="Winder Avellaneda 1" />
+    <img src="winderavellaneda2.jpg" alt="Winder Avellaneda 2" />
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add winderavellaneda.html displaying two images full screen with mobile-first responsive setup.
- Add 30966019.html with identical full-screen image layout.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c098d03a8c8324a57d0a1601a72c84