### PR TITLE
Add floating WhatsApp button to profile pages

### DIFF
--- a/30966019.html
+++ b/30966019.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>30966019</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" />
     <style>
         * {
             margin: 0;
@@ -20,10 +21,32 @@
             height: 100vh;
             object-fit: cover;
         }
+
+        .whatsapp-float {
+            position: fixed;
+            width: 60px;
+            height: 60px;
+            bottom: 20px;
+            right: 20px;
+            background-color: #25d366;
+            color: #fff;
+            border-radius: 50%;
+            text-align: center;
+            font-size: 30px;
+            z-index: 100;
+            box-shadow: 2px 2px 3px rgba(0, 0, 0, 0.3);
+        }
+
+        .whatsapp-float i {
+            margin-top: 15px;
+        }
     </style>
 </head>
 <body>
     <img src="winderavellaneda1.jpg" alt="Winder Avellaneda 1" />
     <img src="winderavellaneda2.jpg" alt="Winder Avellaneda 2" />
+    <a href="https://wa.me/584126783725" class="whatsapp-float" target="_blank" rel="noopener">
+        <i class="fab fa-whatsapp"></i>
+    </a>
 </body>
 </html>

--- a/winderavellaneda.html
+++ b/winderavellaneda.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Winder Avellaneda</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" />
     <style>
         * {
             margin: 0;
@@ -20,10 +21,32 @@
             height: 100vh;
             object-fit: cover;
         }
+
+        .whatsapp-float {
+            position: fixed;
+            width: 60px;
+            height: 60px;
+            bottom: 20px;
+            right: 20px;
+            background-color: #25d366;
+            color: #fff;
+            border-radius: 50%;
+            text-align: center;
+            font-size: 30px;
+            z-index: 100;
+            box-shadow: 2px 2px 3px rgba(0, 0, 0, 0.3);
+        }
+
+        .whatsapp-float i {
+            margin-top: 15px;
+        }
     </style>
 </head>
 <body>
     <img src="winderavellaneda1.jpg" alt="Winder Avellaneda 1" />
     <img src="winderavellaneda2.jpg" alt="Winder Avellaneda 2" />
+    <a href="https://wa.me/584126783725" class="whatsapp-float" target="_blank" rel="noopener">
+        <i class="fab fa-whatsapp"></i>
+    </a>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add floating WhatsApp bubble to winderavellaneda and 30966019 pages linking to +584126783725

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c0af4161dc832481cd0528debcdf23