### PR TITLE
Ajusta tamaño del botón Comprar para móviles

### DIFF
--- a/index.html
+++ b/index.html
@@ -446,6 +446,7 @@
             text-decoration: none;
             border-radius: 4px;
             font-size: 0.85rem;
+            white-space: nowrap;
             transition: var(--transition);
         }
 
@@ -792,8 +793,8 @@
             }
 
             .buy-btn {
-                padding: 3px 6px;
-                font-size: 0.65rem;
+                padding: 2px 5px;
+                font-size: 0.6rem;
             }
         }
 
@@ -837,8 +838,8 @@
             }
 
             .buy-btn {
-                padding: 3px 5px;
-                font-size: 0.65rem;
+                padding: 2px 4px;
+                font-size: 0.55rem;
             }
         }
 


### PR DESCRIPTION
## Summary
- Evita que el texto de los botones "Comprar" se divida en dos líneas al agregar `white-space: nowrap`.
- Reduce el tamaño y el padding de los botones en pantallas pequeñas para mejorar la visualización móvil.

## Testing
- `npm test` *(falla: no se encontró `package.json`)*
- `npx htmlhint index.html` *(falla: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c0af6dcfb88324abf255ec272d08aa