### PR TITLE
Add WhatsApp support button in payment page top bar

### DIFF
--- a/pagos.html
+++ b/pagos.html
@@ -84,6 +84,9 @@
     <nav class="top-bar">
         <a href="index.html" class="top-link"><i class="fas fa-home"></i> Inicio</a>
         <div class="top-right">
+            <a href="https://wa.me/18133584564" class="top-link" target="_blank" rel="noopener">
+                <i class="fas fa-headset"></i> Necesito ayuda
+            </a>
             <a href="#" class="top-link disabled" id="account-link" aria-disabled="true" style="display:none;"><i class="fas fa-user"></i> Mi cuenta</a>
             <a href="#" class="top-link cart-indicator" id="cart-link"><i class="fas fa-shopping-cart"></i><span id="cart-count">0</span></a>
         </div>


### PR DESCRIPTION
## Summary
- Add help button linking to WhatsApp in top navigation of payments page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c0afc389a08324a4dcebcc5fe28d20