### PR TITLE
Make recommended badge green on pagos page

### DIFF
--- a/pagos.css
+++ b/pagos.css
@@ -1492,7 +1492,7 @@
             position: absolute;
             top: 0.8rem;
             right: 0.8rem;
-            background: var(--secondary-color);
+            background: var(--success-color);
             color: var(--white);
             padding: 0.2rem 0.6rem;
             border-radius: var(--radius-sm);


### PR DESCRIPTION
## Summary
- Use success green for `.recommended-badge` to improve visibility

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c13a1719d88324a7e47994e1d161df