### PR TITLE
Mostrar fechas de entrega y ajustar seguro en la pasarela de pago

### DIFF
--- a/pagos.css
+++ b/pagos.css
@@ -1309,34 +1309,10 @@
 
         /* Sección de regalo y opciones de envío mejoradas */
         .gift-section-header {
-            display: flex;
-            align-items: center;
             margin-bottom: 3rem;
         }
 
-        .gift-icon {
-            width: 6rem;
-            height: 6rem;
-            background-color: var(--primary-light);
-            border-radius: 50%;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            font-size: 2.8rem;
-            color: var(--primary-color);
-            margin-right: 2rem;
-            flex-shrink: 0;
-        }
-
-        .gift-info h3 {
-            font-size: 2rem;
-            font-weight: 600;
-            margin-bottom: 0.5rem;
-            color: var(--secondary-color);
-            line-height: 1.3;
-        }
-
-        .gift-info p {
+        .gift-section-header p {
             font-size: 1.5rem;
             color: var(--accent-color);
             line-height: 1.5;
@@ -2975,14 +2951,7 @@
                 gap: 1.5rem;
             }
 
-            .gift-icon {
-                width: 5rem;
-                height: 5rem;
-                font-size: 2.4rem;
-                margin-right: 1.5rem;
-            }
-
-            .gift-info h3 {
+            .gift-section-header p {
                 font-size: 1.8rem;
             }
         }
@@ -3052,15 +3021,6 @@
                 content: attr(data-label) ": ";
                 font-weight: 600;
                 color: var(--accent-color);
-            }
-
-            .gift-section-header {
-                flex-direction: column;
-                align-items: flex-start;
-            }
-
-            .gift-icon {
-                margin-bottom: 1.5rem;
             }
 
             .shipping-option,

--- a/pagos.html
+++ b/pagos.html
@@ -315,17 +315,12 @@
                     <p id="summary-gift">Regalo: ninguno</p>
                     <p id="summary-shipping">Envío: Express ($70.00)</p>
                     <p id="summary-company">Empresa: sin seleccionar</p>
-                    <p id="summary-insurance">Seguro: Premium ($50.00)</p>
+                    <p id="summary-insurance">Seguro: Premium ($100.00)</p>
                 </div>
 
                 <div class="gift-section-header">
-                    <div class="gift-icon">
-                        <i class="fas fa-gift"></i>
-                    </div>
-                    <div class="gift-info">
-                        <h3>¡Elige un regalo GRATIS!</h3>
-                        <p>Como agradecimiento por tu compra, selecciona uno de estos productos para recibirlo completamente gratis con tu pedido.</p>
-                    </div>
+                    <h2 class="section-title"><i class="fas fa-gift"></i> ¡Elige tu regalo GRATIS!</h2>
+                    <p>Como agradecimiento por tu compra, selecciona uno de estos productos para recibirlo completamente gratis con tu pedido.</p>
                 </div>
                 
                 <div class="gift-grid" id="gift-grid">
@@ -345,7 +340,7 @@
                         <div class="shipping-radio"></div>
                         <div class="shipping-info">
                             <div class="shipping-title">
-                                <i class="fas fa-shipping-fast"></i> Express (1-4 días)
+                                <i class="fas fa-shipping-fast"></i> Express - Llega el <span id="express-date"></span>
                             </div>
                             <div class="shipping-description">Entrega rápida con seguimiento completo y notificaciones en tiempo real</div>
                         </div>
@@ -355,7 +350,7 @@
                         <div class="shipping-radio"></div>
                         <div class="shipping-info">
                             <div class="shipping-title">
-                                <i class="fas fa-truck"></i> Estándar (1-10 días)
+                                <i class="fas fa-truck"></i> Estándar - Llega el <span id="standard-date"></span>
                             </div>
                             <div class="shipping-description">Equilibrio entre velocidad y costo, con seguimiento internacional</div>
                         </div>
@@ -365,7 +360,7 @@
                         <div class="shipping-radio"></div>
                         <div class="shipping-info">
                             <div class="shipping-title">
-                                <i class="fas fa-box"></i> Gratuito (15-20 días)
+                                <i class="fas fa-box"></i> Gratuito - Llega el <span id="free-date"></span>
                             </div>
                             <div class="shipping-description">Envío gratuito pero con mayor tiempo de espera, seguimiento básico</div>
                         </div>
@@ -434,7 +429,7 @@
                         </div>
                         <div class="insurance-price">$50.00</div>
                     </div>
-                    <div class="insurance-option premium" data-insurance="true" data-provider="Mercantil" data-price="50">
+                    <div class="insurance-option premium" data-insurance="true" data-provider="Mercantil" data-price="100">
                         <div class="recommended-badge">Recomendado</div>
                         <div class="shipping-radio"></div>
                         <div class="insurance-info">
@@ -444,7 +439,7 @@
                             </div>
                             <div class="insurance-description">Protege tu dispositivo durante 1 año contra daños, robos y pérdidas con cobertura internacional</div>
                         </div>
-                        <div class="insurance-price">$50.00</div>
+                        <div class="insurance-price">$100.00</div>
                     </div>
                     <div class="insurance-option" data-insurance="false" data-price="0">
                         <div class="shipping-radio"></div>

--- a/pagos.js
+++ b/pagos.js
@@ -4,6 +4,9 @@
             const paymentDateEl = document.getElementById('payment-date');
             const preparingDateRangeEl = document.getElementById('preparing-date-range');
             const shippingStartDateEl = document.getElementById('shipping-start-date');
+            const expressDateEl = document.getElementById('express-date');
+            const standardDateEl = document.getElementById('standard-date');
+            const freeDateEl = document.getElementById('free-date');
             const orderDate = new Date();
 
             const formatDate = (date) => {
@@ -36,6 +39,16 @@
                 const shipStart = new Date(orderDate);
                 shipStart.setDate(orderDate.getDate() + 1);
                 shippingStartDateEl.textContent = formatDate(shipStart);
+            }
+
+            if (expressDateEl) {
+                expressDateEl.textContent = formatDate(calculateDeliveryDate('express'));
+            }
+            if (standardDateEl) {
+                standardDateEl.textContent = formatDate(calculateDeliveryDate('standard'));
+            }
+            if (freeDateEl) {
+                freeDateEl.textContent = formatDate(calculateDeliveryDate('free'));
             }
 
             // Elementos de la interfaz


### PR DESCRIPTION
## Summary
- Combina el ícono de regalo con el texto del título y ajusta estilos.
- Muestra la fecha exacta de llegada para envíos express, estándar y gratuito.
- Actualiza el precio del seguro de Mercantil Seguros a $100.

## Testing
- `npm test` *(falla: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c13dbfafcc83248b76ca33b9116963