### PR TITLE
Guard against missing cart modal in payments page

### DIFF
--- a/pagos.html
+++ b/pagos.html
@@ -1062,6 +1062,10 @@
                     cartLink.addEventListener('click', (e) => {
                         e.preventDefault();
                         loadCart();
+                        if (!cartModal) {
+                            console.error('Cart modal element not found');
+                            return;
+                        }
                         cartModal.classList.add('show');
                     });
                 }


### PR DESCRIPTION
## Summary
- ensure cart modal element exists before adding `show`

## Testing
- `node - <<'NODE'
const cartModal={classList:{classes:new Set(),add(c){this.classes.add(c);}}};
function loadCart(){}
const handler=(e)=>{
  e.preventDefault();
  loadCart();
  if(!cartModal){
    console.error('Cart modal element not found');
    return;
  }
  cartModal.classList.add('show');
};
handler({preventDefault:()=>{}});
console.log('has show?',cartModal.classList.classes.has('show'));
NODE`
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c140f3d63483248dc251a063c89763