### PR TITLE
Agregar resumen de envío antes del pago

### DIFF
--- a/pagos.css
+++ b/pagos.css
@@ -2409,6 +2409,45 @@
             justify-content: center;
         }
 
+        /* Overlay de resumen antes de pago */
+        .summary-overlay {
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: rgba(0, 0, 0, 0.4);
+            display: none;
+            align-items: center;
+            justify-content: center;
+            z-index: var(--z-overlay);
+        }
+
+        .summary-overlay.active {
+            display: flex;
+        }
+
+        .summary-modal {
+            background: var(--white);
+            padding: 3rem;
+            border-radius: var(--radius);
+            box-shadow: var(--shadow-lg);
+            max-width: 50rem;
+            width: 90%;
+        }
+
+        .summary-details p {
+            margin: 0.5rem 0;
+        }
+
+        .summary-actions {
+            margin-top: 2rem;
+            display: flex;
+            gap: 1rem;
+            justify-content: flex-end;
+            flex-wrap: wrap;
+        }
+
         /* Overlay de validación */
         .validation-overlay {
             position: fixed;

--- a/pagos.html
+++ b/pagos.html
@@ -821,6 +821,25 @@
         </div>
     </div>
 
+    <!-- Overlay de resumen antes de pago -->
+    <div class="summary-overlay" id="summary-overlay">
+        <div class="summary-modal">
+            <h3>Confirma tu información</h3>
+            <div class="summary-details">
+                <p id="summary-overlay-gift"></p>
+                <p id="summary-overlay-shipping"></p>
+                <p id="summary-overlay-company"></p>
+                <p id="summary-overlay-insurance"></p>
+                <p id="summary-overlay-delivery"></p>
+                <p id="summary-overlay-tax"></p>
+            </div>
+            <div class="summary-actions">
+                <button class="btn btn-secondary" id="summary-edit">Editar</button>
+                <button class="btn btn-primary" id="summary-accept">Aceptar</button>
+            </div>
+        </div>
+    </div>
+
     <!-- Loading Overlay Mejorado -->
     <div class="loading-overlay" id="loading-overlay">
         <div class="loader">

--- a/pagos.js
+++ b/pagos.js
@@ -130,6 +130,15 @@
             const shippingOptionsContainer = document.querySelector('.shipping-options');
             const shippingCompanyContainer = document.getElementById('shipping-company-container');
             const downloadInvoiceBtn = document.getElementById('download-invoice');
+            const summaryOverlay = document.getElementById('summary-overlay');
+            const summaryOverlayGift = document.getElementById('summary-overlay-gift');
+            const summaryOverlayShipping = document.getElementById('summary-overlay-shipping');
+            const summaryOverlayCompany = document.getElementById('summary-overlay-company');
+            const summaryOverlayInsurance = document.getElementById('summary-overlay-insurance');
+            const summaryOverlayDelivery = document.getElementById('summary-overlay-delivery');
+            const summaryOverlayTax = document.getElementById('summary-overlay-tax');
+            const summaryEditBtn = document.getElementById('summary-edit');
+            const summaryAcceptBtn = document.getElementById('summary-accept');
             const deliveryDateStart = document.getElementById('delivery-date-start');
             const deliveryDateStart2 = document.getElementById('delivery-date-start-2');
             const deliveryDateEnd = document.getElementById('delivery-date-end');
@@ -2004,8 +2013,36 @@
                     return;
                 }
 
-                goToStep(3);
-                updatePaymentSummary();
+                const requiredInputs = [fullNameInput, idNumberInput, phoneInput, stateInput, cityInput, shippingCompanyInput, addressInput].filter(Boolean);
+                const emptyInput = requiredInputs.find(field => !field.value.trim());
+                if (emptyInput) {
+                    showToast('warning', 'Datos incompletos', 'Por favor, completa la información de entrega.');
+                    emptyInput.focus();
+                    return;
+                }
+
+                if (summaryOverlayGift) {
+                    summaryOverlayGift.textContent = selectedGift ? `Regalo: ${selectedGift.name}` : 'Regalo: ninguno';
+                }
+                if (summaryOverlayShipping) {
+                    summaryOverlayShipping.textContent = `Envío: ${shippingMethod.textContent} ($${selectedShipping.price.toFixed(2)})`;
+                }
+                if (summaryOverlayCompany) {
+                    summaryOverlayCompany.textContent = `Empresa de transporte: ${shippingCompanyInput.value}`;
+                }
+                if (summaryOverlayInsurance) {
+                    summaryOverlayInsurance.textContent = selectedInsurance.selected ? `Seguro: ${selectedInsurance.provider} ($${selectedInsurance.price.toFixed(2)})` : 'Seguro: sin seguro';
+                }
+                if (summaryOverlayDelivery) {
+                    summaryOverlayDelivery.textContent = `Tiempo de entrega: ${deliveryDateStart2.textContent} - ${deliveryDateEnd.textContent}`;
+                }
+                if (summaryOverlayTax) {
+                    summaryOverlayTax.textContent = `Tasa de nacionalización: ${taxAmountBs.textContent} Bs`;
+                }
+
+                if (summaryOverlay) {
+                    summaryOverlay.classList.add('active');
+                }
             });
 
             backToShippingBtn.addEventListener('click', () => {
@@ -2015,6 +2052,28 @@
             processPaymentBtn.addEventListener('click', () => {
                 processPayment();
             });
+
+            if (summaryEditBtn) {
+                summaryEditBtn.addEventListener('click', () => {
+                    summaryOverlay.classList.remove('active');
+                });
+            }
+
+            if (summaryAcceptBtn) {
+                summaryAcceptBtn.addEventListener('click', () => {
+                    summaryOverlay.classList.remove('active');
+                    goToStep(3);
+                    updatePaymentSummary();
+                });
+            }
+
+            if (summaryOverlay) {
+                summaryOverlay.addEventListener('click', (e) => {
+                    if (e.target === summaryOverlay) {
+                        summaryOverlay.classList.remove('active');
+                    }
+                });
+            }
 
             // 4. Opciones de envío
             function applyShippingSelection(option) {


### PR DESCRIPTION
## Summary
- Mostrar un overlay con el resumen de regalo, envío, empresa y seguro antes de pasar al pago
- Validar que los datos de entrega estén completos al continuar
- Estilos y controles para aceptar o editar el resumen

## Testing
- `npm test` *(falla: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1447eff8c8324817e6b5ee0502c5a