### PR TITLE
Emit cart-updated event after cart changes

### DIFF
--- a/pagos.js
+++ b/pagos.js
@@ -986,7 +986,7 @@
                 }
 
                 // Actualizar la interfaz del carrito
-                updateCart();
+                window.dispatchEvent(new Event('cart-updated'));
             }
 
             // Función para eliminar del carrito
@@ -1002,7 +1002,7 @@
                     } catch (err) {
                         console.error('Error al guardar el carrito', err);
                     }
-                    updateCart();
+                    window.dispatchEvent(new Event('cart-updated'));
 
                     // Notificar al usuario
                     showToast('info', 'Producto eliminado', `Has eliminado ${removedItem.name} de tu carrito.`);
@@ -1110,7 +1110,7 @@
                             } catch (err) {
                                 console.error('Error al guardar el carrito', err);
                             }
-                            updateCart();
+                            window.dispatchEvent(new Event('cart-updated'));
                         }
                     });
                 });
@@ -1128,7 +1128,7 @@
                             } catch (err) {
                                 console.error('Error al guardar el carrito', err);
                             }
-                            updateCart();
+                            window.dispatchEvent(new Event('cart-updated'));
                         }
                     });
                 });
@@ -1147,7 +1147,7 @@
                             } catch (err) {
                                 console.error('Error al guardar el carrito', err);
                             }
-                            updateCart();
+                            window.dispatchEvent(new Event('cart-updated'));
                         } else {
                             input.value = 1;
                         }


### PR DESCRIPTION
## Summary
- Dispatch `cart-updated` event after adding, removing, or changing quantities in the cart so other components can update
- Ensure `updateCart` only responds to the event and no longer triggers itself to prevent loops

## Testing
- `node --check pagos.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c14c174680832499196c7e24b5a3c6