### PR TITLE
Normalize base styles for payments

### DIFF
--- a/pagos.css
+++ b/pagos.css
@@ -1,3 +1,41 @@
+        /* Normalize */
+        html {
+            line-height: 1.15;
+            -webkit-text-size-adjust: 100%;
+        }
+
+        body {
+            margin: 0;
+        }
+
+        *, *::before, *::after {
+            box-sizing: border-box;
+            margin: 0;
+            padding: 0;
+            -webkit-tap-highlight-color: transparent;
+        }
+
+        button,
+        input,
+        textarea,
+        select {
+            font: inherit;
+            margin: 0;
+        }
+
+        ul,
+        ol {
+            list-style: none;
+            margin: 0;
+            padding: 0;
+        }
+
+        h1, h2, h3, h4, h5, h6 {
+            font-size: inherit;
+            font-weight: inherit;
+            margin: 0;
+        }
+
         :root {
             --primary-color: #0071e3;
             --primary-hover: #0062c3;
@@ -37,13 +75,6 @@
             --z-toast: 1004;
             --max-width: 1280px;
             --font-main: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
-        }
-
-        *, *::before, *::after {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-            -webkit-tap-highlight-color: transparent;
         }
 
         html {


### PR DESCRIPTION
## Summary
- add normalize snippet for html, body, form controls, lists, and headings in `pagos.css`
- ensure `*, *::before, *::after` keeps `box-sizing: border-box` and standardize reset rules

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c15507cb208324a5d7085119dbfb0e