### PR TITLE
Improve focus visibility for form elements

### DIFF
--- a/components.css
+++ b/components.css
@@ -320,7 +320,10 @@
     border: none;
     border-radius: 20px;
     font-size: 1.4rem;
-    outline: none;
+}
+
+.whatsapp-widget-footer input:focus {
+    box-shadow: 0 0 0 3px rgba(0,113,227,.4);
 }
 
 .send-button {
@@ -564,7 +567,6 @@
 .contact-form input:focus,
 .contact-form textarea:focus,
 .contact-form select:focus {
-    outline: none;
     border-color: var(--primary-color);
     box-shadow: 0 0 0 2px rgba(121, 40, 202, 0.1);
 }
@@ -694,7 +696,6 @@
 }
 
 .tracking-form input:focus {
-    outline: none;
     border-color: var(--primary-color);
     box-shadow: 0 0 0 2px rgba(121, 40, 202, 0.1);
 }

--- a/moviles.css
+++ b/moviles.css
@@ -36,7 +36,7 @@
 }
 
 .search-bar input:focus {
-    outline: none;
+    box-shadow: 0 0 0 3px rgba(0,113,227,.4);
 }
 
 .search-bar button {
@@ -353,8 +353,8 @@
 }
 
 .filter-sort select:focus {
-    outline: none;
     border-color: var(--primary-color);
+    box-shadow: 0 0 0 3px rgba(0,113,227,.4);
 }
 
 /* Productos Grid */

--- a/pagos.css
+++ b/pagos.css
@@ -901,7 +901,7 @@
         }
 
         .quantity-input:focus {
-            outline: none;
+            box-shadow: 0 0 0 3px rgba(0,113,227,.4);
         }
 
         .add-to-cart-btn {
@@ -1267,13 +1267,16 @@
             font-size: 1.6rem;
             transition: var(--transition);
             border: none;
-            outline: none;
             cursor: pointer;
             white-space: nowrap;
             box-shadow: var(--shadow-sm);
             position: relative;
             overflow: hidden;
             touch-action: manipulation;
+        }
+
+        .btn:focus {
+            box-shadow: 0 0 0 3px rgba(0,113,227,.4);
         }
 
         .btn::before {
@@ -2032,7 +2035,6 @@
         }
 
         .form-input:focus {
-            outline: none;
             border-color: var(--primary-color);
             box-shadow: 0 0 0 0.3rem rgba(0, 113, 227, 0.2);
         }


### PR DESCRIPTION
## Summary
- Replace outline removal with high-contrast focus shadow on `.quantity-input`
- Add accessible focus styles to buttons, search inputs, selects, and WhatsApp widget input
- Ensure form controls provide custom focus styles instead of removing outline

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1616ead208324b7b99f0a2ee9227c