### PR TITLE
Add store pickup shipping option and standardize insurance cards

### DIFF
--- a/pagos.css
+++ b/pagos.css
@@ -1506,6 +1506,12 @@
             width: 22rem;
         }
 
+        .shipping-option.disabled {
+            opacity: 0.5;
+            cursor: not-allowed;
+            pointer-events: none;
+        }
+
         .recommended-badge {
             position: absolute;
             top: 0.8rem;
@@ -1690,10 +1696,6 @@
             transition: var(--transition);
         }
 
-        .insurance-option.premium::before {
-            background: linear-gradient(to bottom, #4cd964, #34c759);
-        }
-
         .insurance-option:hover {
             transform: translateY(-0.5rem);
             box-shadow: var(--shadow);
@@ -1706,12 +1708,8 @@
         .insurance-option.selected {
             border-color: var(--primary-color);
             box-shadow: var(--shadow);
-            padding-left: 2.5rem;
-        }
-
-        .insurance-option.premium.selected {
-            border-color: #4cd964;
-            background-color: rgba(76, 217, 100, 0.1);
+            padding-left: var(--space-md);
+            background-color: var(--primary-light);
         }
 
         .insurance-option.selected::before {
@@ -1745,6 +1743,11 @@
             object-fit: contain;
         }
 
+        .insurance-title .insurance-logo {
+            font-size: 2.4rem;
+            color: var(--accent-color);
+        }
+
         .insurance-description {
             font-size: 1.4rem;
             color: var(--accent-color);
@@ -1758,10 +1761,6 @@
             flex-shrink: 0;
             color: var(--primary-color);
             white-space: nowrap;
-        }
-
-        .insurance-option.premium .insurance-price {
-            color: #4cd964;
         }
 
         /* Notificación de tasas mejorada */

--- a/pagos.html
+++ b/pagos.html
@@ -366,6 +366,16 @@
                         </div>
                         <div class="shipping-price">$0.00</div>
                     </div>
+                    <div class="shipping-option disabled" data-shipping="pickup" data-price="0">
+                        <div class="shipping-radio"></div>
+                        <div class="shipping-info">
+                            <div class="shipping-title">
+                                <i class="fas fa-store"></i> Retirar en tienda
+                            </div>
+                            <div class="shipping-description">Retiro gratuito en nuestra tienda física (próximamente)</div>
+                        </div>
+                        <div class="shipping-price">$0.00</div>
+                    </div>
                 </div>
 
                 <div id="shipping-summary" class="summary-card hidden">
@@ -406,8 +416,8 @@
 
                 <h2 class="section-title" style="margin-top: 5rem;"><i class="fas fa-shield-alt"></i> Seguro de equipo (opcional)</h2>
 
-                <div class="insurance-options shipping-company-grid">
-                    <div class="insurance-option premium" data-insurance="true" data-provider="Allianz" data-price="50">
+                <div class="insurance-options">
+                    <div class="insurance-option" data-insurance="true" data-provider="Allianz" data-price="50">
                         <div class="shipping-radio"></div>
                         <div class="insurance-info">
                             <div class="insurance-title">
@@ -418,7 +428,7 @@
                         </div>
                         <div class="insurance-price">$50.00</div>
                     </div>
-                    <div class="insurance-option premium" data-insurance="true" data-provider="Zurich" data-price="50">
+                    <div class="insurance-option" data-insurance="true" data-provider="Zurich" data-price="50">
                         <div class="shipping-radio"></div>
                         <div class="insurance-info">
                             <div class="insurance-title">
@@ -429,7 +439,7 @@
                         </div>
                         <div class="insurance-price">$50.00</div>
                     </div>
-                    <div class="insurance-option premium" data-insurance="true" data-provider="Mercantil" data-price="100">
+                    <div class="insurance-option" data-insurance="true" data-provider="Mercantil" data-price="100">
                         <div class="recommended-badge">Recomendado</div>
                         <div class="shipping-radio"></div>
                         <div class="insurance-info">
@@ -445,7 +455,7 @@
                         <div class="shipping-radio"></div>
                         <div class="insurance-info">
                             <div class="insurance-title">
-                                <i class="fas fa-times-circle" style="color: var(--accent-color);"></i>
+                                <i class="fas fa-times-circle insurance-logo"></i>
                                 Sin seguro
                             </div>
                             <div class="insurance-description">No incluir seguro adicional para el dispositivo</div>

--- a/pagos.js
+++ b/pagos.js
@@ -2539,6 +2539,7 @@
             }
 
             shippingOptions.forEach(option => {
+                if (option.classList.contains('disabled')) return;
                 option.addEventListener('click', () => {
                     const method = option.getAttribute('data-shipping');
                     if (method === 'free' && freeShippingOverlay) {


### PR DESCRIPTION
## Summary
- Add disabled "Retirar en tienda" shipping option
- Standardize insurance card layout and color scheme
- Ignore disabled shipping option in selection logic

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1628550c08324a7308e119b0a25c0