### PR TITLE
Allow manual shipping company entry

### DIFF
--- a/pagos.js
+++ b/pagos.js
@@ -2429,7 +2429,10 @@
                 if (!document.querySelector('.shipping-option.selected')) {
                     missing.push('el método de envío');
                 }
-                if (!document.querySelector('.shipping-company-card.selected')) {
+                if (
+                    !document.querySelector('.shipping-company-card.selected') &&
+                    (!shippingCompanyInput || !shippingCompanyInput.value.trim())
+                ) {
                     missing.push('la empresa de envío');
                 }
                 if (!document.querySelector('.insurance-option.selected')) {


### PR DESCRIPTION
## Summary
- Validate shipping company using either card selection or manual input so checkout can proceed

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c16404bdd48324a8ab02553c0e4dd7