### PR TITLE
feat: highlight focus states for buttons

### DIFF
--- a/pagos.css
+++ b/pagos.css
@@ -1276,7 +1276,9 @@
         }
 
         .btn:focus {
-            box-shadow: 0 0 0 3px rgba(0,113,227,.4);
+            outline: 2px solid var(--primary-color);
+            outline-offset: 2px;
+            box-shadow: 0 0 0 3px rgba(0, 113, 227, 0.4);
         }
 
         .btn::before {
@@ -1330,6 +1332,18 @@
         .btn-secondary:active {
             transform: translateY(0);
             box-shadow: var(--shadow-sm);
+        }
+
+        .btn-primary:focus {
+            outline: 2px solid var(--white);
+            outline-offset: 2px;
+            box-shadow: 0 0 0 3px rgba(0, 113, 227, 0.6);
+        }
+
+        .btn-secondary:focus {
+            outline: 2px solid var(--secondary-color);
+            outline-offset: 2px;
+            box-shadow: 0 0 0 3px rgba(29, 29, 31, 0.4);
         }
 
         .btn-block {


### PR DESCRIPTION
## Summary
- improve button focus styles with outline and shadow
- add dedicated focus states for primary and secondary buttons to enhance accessibility

## Testing
- `npm test` (fails: package.json not found)
- `npx lighthouse pagos.html --quiet --no-update-notifier --chrome-flags="--headless"` (fails: 403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_68c165a1a9d08324944cd0815bd62fed