### PR TITLE
Validar selección de ubicación antes de proceder al pago

### DIFF
--- a/pagos.js
+++ b/pagos.js
@@ -509,6 +509,13 @@
 
             if (locationConfirm) {
                 locationConfirm.addEventListener('click', () => {
+                    // Evitar que se borren los campos cuando no se ha
+                    // seleccionado una ubicación válida
+                    if (!locationStateSelect.value || !locationCitySelect.value) {
+                        showValidationOverlay('Por favor, selecciona un estado y una ciudad.');
+                        return;
+                    }
+
                     stateInput.value = locationStateSelect.value;
                     cityInput.value = locationCitySelect.value;
                     locationOverlay.classList.remove('active');


### PR DESCRIPTION
## Summary
- Evita que la selección de estado y ciudad se confirme si no se escogieron valores válidos.
- Muestra un mensaje de validación para que el usuario complete la ubicación antes de continuar.

## Testing
- `npm test` *(falls: ENOENT Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c166e40348832494872d76b5a239b4