### PR TITLE
Validate delivery info at payment stage

### DIFF
--- a/pagos.html
+++ b/pagos.html
@@ -576,6 +576,59 @@
                     </div>
                 </div>
 
+                <div class="delivery-form-section">
+                    <h3 style="font-size: 2.4rem; margin-bottom: 3rem;">Completa tu información de entrega</h3>
+
+                    <p style="max-width: 70rem; margin: 0 auto 3rem; color: var(--accent-color);">Para finalizar tu pedido, necesitamos algunos datos adicionales para la entrega. Por favor, completa el siguiente formulario:</p>
+
+                    <div class="delivery-form-container">
+                        <div class="delivery-form-header">
+                            <div class="delivery-form-title">
+                                <i class="fas fa-address-card"></i> Formulario de entrega LatinPhone
+                            </div>
+                        </div>
+
+                        <!-- Formulario de entrega mejorado -->
+                        <div class="delivery-form">
+                            <div class="delivery-form-grid">
+                                <div class="form-group">
+                                    <label class="form-label required">Nombre completo</label>
+                                    <input type="text" id="full-name" class="form-input" placeholder="Nombre y apellido" required>
+                                </div>
+                                <div class="form-group">
+                                    <label class="form-label required">Cédula</label>
+                                    <input type="text" id="id-number" class="form-input" placeholder="V-12345678" required>
+                                </div>
+                                <div class="form-group">
+                                    <label class="form-label required">Teléfono</label>
+                                    <input type="tel" id="phone" class="form-input" placeholder="+58 412-1234567" required>
+                                </div>
+                                <div class="form-group">
+                                    <label class="form-label required">Estado</label>
+                                    <input type="text" id="state" class="form-input" placeholder="Estado" required>
+                                </div>
+                                <div class="form-group">
+                                    <label class="form-label required">Ciudad</label>
+                                    <input type="text" id="city" class="form-input" placeholder="Ciudad" required>
+                                </div>
+                                <div class="form-group">
+                                    <label class="form-label required">Empresa de envío</label>
+                                    <input type="text" id="shipping-company-input" class="form-input" placeholder="Nombre de la empresa" required>
+                                </div>
+                                <div class="form-group" style="grid-column: span 2;">
+                                    <label class="form-label required">Dirección de casa</label>
+                                    <textarea id="address" class="form-input" rows="3" placeholder="Dirección detallada para entrega" required></textarea>
+                                </div>
+                                <div class="form-group" style="grid-column: span 2; text-align: center; margin-top: 1rem;">
+                                    <button class="btn btn-primary" id="send-delivery-info" style="min-width: 20rem;">
+                                        <i class="fas fa-paper-plane btn-icon"></i>Enviar información
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
                 <div class="checkout-grid" style="margin-top: 5rem;">
                     <div style="grid-column: 1 / -1;">
                         <h2 class="section-title"><i class="fas fa-shopping-basket"></i> Resumen de la compra</h2>
@@ -736,59 +789,6 @@
                                     <h4 class="timeline-title">Entrega estimada</h4>
                                     <p class="timeline-text">Recibirás tu pedido entre estas fechas.</p>
                                     <p class="timeline-date"><span id="delivery-date-start-2"></span> - <span id="delivery-date-end"></span></p>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div class="delivery-form-section">
-                        <h3 style="font-size: 2.4rem; margin-bottom: 3rem;">Completa tu información de entrega</h3>
-                        
-                        <p style="max-width: 70rem; margin: 0 auto 3rem; color: var(--accent-color);">Para finalizar tu pedido, necesitamos algunos datos adicionales para la entrega. Por favor, completa el siguiente formulario:</p>
-                        
-                        <div class="delivery-form-container">
-                            <div class="delivery-form-header">
-                                <div class="delivery-form-title">
-                                    <i class="fas fa-address-card"></i> Formulario de entrega LatinPhone
-                                </div>
-                            </div>
-                            
-                            <!-- Formulario de entrega mejorado -->
-                            <div class="delivery-form">
-                                <div class="delivery-form-grid">
-                                    <div class="form-group">
-                                        <label class="form-label required">Nombre completo</label>
-                                        <input type="text" id="full-name" class="form-input" placeholder="Nombre y apellido" required>
-                                    </div>
-                                    <div class="form-group">
-                                        <label class="form-label required">Cédula</label>
-                                        <input type="text" id="id-number" class="form-input" placeholder="V-12345678" required>
-                                    </div>
-                                    <div class="form-group">
-                                        <label class="form-label required">Teléfono</label>
-                                        <input type="tel" id="phone" class="form-input" placeholder="+58 412-1234567" required>
-                                    </div>
-                                    <div class="form-group">
-                                        <label class="form-label required">Estado</label>
-                                        <input type="text" id="state" class="form-input" placeholder="Estado" required>
-                                    </div>
-                                    <div class="form-group">
-                                        <label class="form-label required">Ciudad</label>
-                                        <input type="text" id="city" class="form-input" placeholder="Ciudad" required>
-                                    </div>
-                                    <div class="form-group">
-                                        <label class="form-label required">Empresa de envío</label>
-                                        <input type="text" id="shipping-company-input" class="form-input" placeholder="Nombre de la empresa" required>
-                                    </div>
-                                    <div class="form-group" style="grid-column: span 2;">
-                                        <label class="form-label required">Dirección de casa</label>
-                                        <textarea id="address" class="form-input" rows="3" placeholder="Dirección detallada para entrega" required></textarea>
-                                    </div>
-                                    <div class="form-group" style="grid-column: span 2; text-align: center; margin-top: 1rem;">
-                                        <button class="btn btn-primary" id="send-delivery-info" style="min-width: 20rem;">
-                                            <i class="fas fa-paper-plane btn-icon"></i>Enviar información
-                                        </button>
-                                    </div>
                                 </div>
                             </div>
                         </div>

--- a/pagos.js
+++ b/pagos.js
@@ -2454,13 +2454,13 @@
                     return;
                 }
 
-                const requiredInputs = [fullNameInput, idNumberInput, phoneInput, stateInput, cityInput, shippingCompanyInput, addressInput].filter(Boolean);
-                const emptyInput = requiredInputs.find(field => !field.value.trim());
-                if (emptyInput) {
-                    showToast('warning', 'Datos incompletos', 'Por favor, completa la información de entrega.');
-                    emptyInput.focus();
-                    return;
-                }
+                // const requiredInputs = [fullNameInput, idNumberInput, phoneInput, stateInput, cityInput, shippingCompanyInput, addressInput].filter(Boolean);
+                // const emptyInput = requiredInputs.find(field => !field.value.trim());
+                // if (emptyInput) {
+                //     showToast('warning', 'Datos incompletos', 'Por favor, completa la información de entrega.');
+                //     emptyInput.focus();
+                //     return;
+                // }
 
                 if (summaryOverlayGift) {
                     summaryOverlayGift.textContent = selectedGift ? `Regalo: ${selectedGift.name}` : 'Regalo: ninguno';
@@ -2491,6 +2491,13 @@
             });
 
             processPaymentBtn.addEventListener('click', () => {
+                const requiredInputs = [fullNameInput, idNumberInput, phoneInput, stateInput, cityInput, shippingCompanyInput, addressInput].filter(Boolean);
+                const emptyInput = requiredInputs.find(field => !field.value.trim());
+                if (emptyInput) {
+                    showToast('warning', 'Datos incompletos', 'Por favor, completa la información de entrega.');
+                    emptyInput.focus();
+                    return;
+                }
                 processPayment();
             });
 


### PR DESCRIPTION
## Summary
- Remove premature delivery-form validation when continuing to payment
- Add delivery-field checks before processing payment
- Move delivery form earlier so it is visible prior to validation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c16b577cf48324b4a3d54a304bd843