### PR TITLE
feat: add alert roles and styles for form messages

### DIFF
--- a/pagos.css
+++ b/pagos.css
@@ -191,6 +191,24 @@
             margin-bottom: var(--space-md);
         }
 
+        .form-error,
+        .form-success {
+            font-family: var(--font-main);
+            font-size: 1.4rem;
+            line-height: 1.5;
+            margin-top: var(--space-sm);
+            text-align: center;
+            display: none;
+        }
+
+        .form-error {
+            color: var(--error-color);
+        }
+
+        .form-success {
+            color: var(--success-color);
+        }
+
         /* Estilos para la cabecera de la página de pago */
         .checkout-header {
             text-align: center;

--- a/pagos.html
+++ b/pagos.html
@@ -567,7 +567,7 @@
                             <p>Verificando comprobante...</p>
                             <div class="spinner"></div>
                         </div>
-                        <div id="zelle-result" style="display:none;text-align:center;margin-top:1rem;color:var(--error-color);"></div>
+                        <div id="zelle-result" class="form-error" role="alert"></div>
                     </div>
 
                     <div id="paypal-info" class="payment-info" style="display: none;">
@@ -929,7 +929,7 @@
     <!-- Overlay de validación -->
     <div class="validation-overlay" id="validation-overlay">
         <div class="validation-modal">
-            <p id="validation-message"></p>
+            <p id="validation-message" class="form-error" role="alert"></p>
             <button class="btn btn-primary" id="validation-close">Entendido</button>
         </div>
     </div>

--- a/pagos.js
+++ b/pagos.js
@@ -157,6 +157,13 @@
             const zelleReceipt = document.getElementById('zelle-receipt');
             const zelleVerification = document.getElementById('zelle-verification');
             const zelleResult = document.getElementById('zelle-result');
+
+            const showZelleResult = (message, type = 'error') => {
+                if (!zelleResult) return;
+                zelleResult.className = type === 'success' ? 'form-success' : 'form-error';
+                zelleResult.textContent = message;
+                zelleResult.style.display = 'block';
+            };
             const paypalInfo = document.getElementById('paypal-info');
             const whatsappBtn = document.getElementById('whatsapp-btn');
             const whatsappSupport = document.getElementById('whatsapp-support');
@@ -900,9 +907,10 @@
             let giftProducts = [];
 
             // Notificaciones deshabilitadas
-            function showValidationOverlay(message) {
+            function showValidationOverlay(message, type = 'error') {
                 if (validationMessage) {
                     validationMessage.textContent = message;
+                    validationMessage.className = type === 'success' ? 'form-success' : 'form-error';
                 }
                 if (validationOverlay) {
                     validationOverlay.classList.add('active');
@@ -2671,6 +2679,7 @@
                         if (zelleTimer) clearTimeout(zelleTimer);
                         zelleVerification.style.display = 'none';
                         zelleResult.style.display = 'none';
+                        zelleResult.textContent = '';
                     }
 
                     // Notificar al usuario
@@ -2682,10 +2691,10 @@
                 if (zelleTimer) clearTimeout(zelleTimer);
                 zelleVerification.style.display = 'block';
                 zelleResult.style.display = 'none';
+                zelleResult.textContent = '';
                 zelleTimer = setTimeout(() => {
                     zelleVerification.style.display = 'none';
-                    zelleResult.style.display = 'block';
-                    zelleResult.textContent = 'No pudimos verificar tu pago con Zelle. Por favor, comunícate con tu banco.';
+                    showZelleResult('No pudimos verificar tu pago con Zelle. Por favor, comunícate con tu banco.', 'error');
                     showToast('error', 'Pago rechazado', 'No pudimos verificar tu pago con Zelle. Comunícate con tu banco.');
                 }, 180000);
             });


### PR DESCRIPTION
## Summary
- style new `.form-error` and `.form-success` helpers with theme colors and spacing
- mark Zelle result and validation messages as ARIA alerts for screen readers
- centralize Zelle verification feedback logic

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node - <<'NODE' ... (simulated showZelleResult)`
- `node - <<'NODE' ... (simulated showValidationOverlay)`

------
https://chatgpt.com/codex/tasks/task_e_68c16daefa788324b223de28a80eb75d