### PR TITLE
Fix validation overlay visibility for payment overlay

### DIFF
--- a/pagos.js
+++ b/pagos.js
@@ -566,6 +566,9 @@
             if (validationClose) {
                 validationClose.addEventListener('click', () => {
                     validationOverlay.classList.remove('active');
+                    if (validationMessage) {
+                        validationMessage.style.display = 'none';
+                    }
                 });
             }
 
@@ -911,6 +914,7 @@
                 if (validationMessage) {
                     validationMessage.textContent = message;
                     validationMessage.className = type === 'success' ? 'form-success' : 'form-error';
+                    validationMessage.style.display = 'block';
                 }
                 if (validationOverlay) {
                     validationOverlay.classList.add('active');


### PR DESCRIPTION
## Summary
- Display validation message when triggering overlay
- Hide validation message when overlay closes

## Testing
- `node --check pagos.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c2bb2fcc83248b402966ad63090d