### PR TITLE
Close validation modal on Escape and overlay click

### DIFF
--- a/pagos.js
+++ b/pagos.js
@@ -563,11 +563,27 @@
                 });
             }
 
+            const hideValidationOverlay = () => {
+                validationOverlay.classList.remove('active');
+                if (validationMessage) {
+                    validationMessage.style.display = 'none';
+                }
+            };
+
             if (validationClose) {
-                validationClose.addEventListener('click', () => {
-                    validationOverlay.classList.remove('active');
-                    if (validationMessage) {
-                        validationMessage.style.display = 'none';
+                validationClose.addEventListener('click', hideValidationOverlay);
+            }
+
+            document.addEventListener('keydown', (e) => {
+                if (e.key === 'Escape' && validationOverlay.classList.contains('active')) {
+                    hideValidationOverlay();
+                }
+            });
+
+            if (validationOverlay) {
+                validationOverlay.addEventListener('click', (e) => {
+                    if (e.target === validationOverlay) {
+                        hideValidationOverlay();
                     }
                 });
             }


### PR DESCRIPTION
## Summary
- Add `hideValidationOverlay` function to manage closing the validation modal
- Close validation modal on Escape key and clicking outside the modal

## Testing
- `node --check pagos.js`


------
https://chatgpt.com/codex/tasks/task_e_68c1c45f610483249dd850cbb1121cd5