### PR TITLE
Keep account link visible and top bar horizontal

### DIFF
--- a/pagos.css
+++ b/pagos.css
@@ -155,6 +155,7 @@
         .top-link.disabled {
             opacity: 0.5;
             cursor: not-allowed;
+            pointer-events: none;
         }
 
         .cart-indicator {
@@ -3703,21 +3704,21 @@
     }
 
     .top-bar {
-        flex-direction: column;
-        align-items: flex-start;
+        flex-direction: row;
+        align-items: center;
         height: auto;
         padding: var(--space-sm);
     }
 
     .top-right {
-        flex-direction: column;
-        width: 100%;
-        margin-top: var(--space-sm);
+        flex-direction: row;
+        width: auto;
+        margin-top: 0;
         gap: var(--space-sm);
     }
 
     .top-bar .top-link {
-        width: 100%;
+        width: auto;
         justify-content: center;
     }
 

--- a/pagos.html
+++ b/pagos.html
@@ -25,10 +25,10 @@
     <nav class="top-bar">
         <a href="index.html" class="top-link"><i class="fas fa-home"></i> Inicio</a>
         <div class="top-right">
+            <a href="#" class="top-link disabled" id="account-link" aria-disabled="true"><i class="fas fa-user"></i> Mi cuenta</a>
             <a href="https://wa.me/18133584564" class="top-link" target="_blank" rel="noopener">
                 <i class="fas fa-headset"></i> Necesito ayuda
             </a>
-            <a href="#" class="top-link disabled" id="account-link" aria-disabled="true" style="display:none;"><i class="fas fa-user"></i> Mi cuenta</a>
             <a href="#" class="top-link cart-indicator" id="cart-link"><i class="fas fa-shopping-cart"></i><span id="cart-count">0</span></a>
         </div>
     </nav>

--- a/pagos.js
+++ b/pagos.js
@@ -2067,7 +2067,6 @@
                     const storedUser = JSON.parse(localStorage.getItem('lpUser') || '{}');
                     const hasInfo = storedUser.name && storedUser.doc && storedUser.phone;
                     accountLink.setAttribute('href', hasInfo ? 'micuenta.html' : 'informacion.html');
-                    accountLink.style.display = 'inline-block';
                 }
 
             setTimeout(() => {


### PR DESCRIPTION
## Summary
- Reorder top-bar links so "Mi cuenta" is shown but disabled ahead of help and cart links.
- Ensure disabled top links are non-interactive and keep top bar layout horizontal on small screens.
- Remove runtime display toggling for the account link, relying on class changes after purchase.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c579178c83248f38ca5737b84984