### PR TITLE
feat: collect email and confirm info before payment

### DIFF
--- a/pagos.html
+++ b/pagos.html
@@ -522,6 +522,10 @@
                                     <input type="tel" id="phone" class="form-input" placeholder="+58 412-1234567" required>
                                 </div>
                                 <div class="form-group">
+                                    <label class="form-label required" for="email">Correo electrónico</label>
+                                    <input type="email" id="email" class="form-input" placeholder="usuario@correo.com" required>
+                                </div>
+                                <div class="form-group">
                                     <label class="form-label required" for="state">Estado</label>
                                     <input type="text" id="state" class="form-input" placeholder="Estado" required>
                                 </div>
@@ -538,8 +542,8 @@
                                     <textarea id="address" class="form-input" rows="3" placeholder="Dirección detallada para entrega" required></textarea>
                                 </div>
                                 <div class="form-actions full-width" style="text-align: center; margin-top: 1rem;">
-                                    <button class="btn btn-primary" id="send-delivery-info" style="min-width: 20rem;">
-                                        <i class="fas fa-paper-plane btn-icon"></i>Enviar información
+                                    <button class="btn btn-primary" id="save-user-info" style="min-width: 20rem;">
+                                        <i class="fas fa-save btn-icon"></i>Guardar información
                                     </button>
                                 </div>
                             </div>
@@ -838,6 +842,27 @@
                 <h3>Confirma tu información</h3>
             </div>
             <div class="summary-details">
+                <div class="summary-item">
+                    <i class="fas fa-user"></i><span id="summary-full-name"></span>
+                </div>
+                <div class="summary-item">
+                    <i class="fas fa-id-card"></i><span id="summary-id-number"></span>
+                </div>
+                <div class="summary-item">
+                    <i class="fas fa-phone"></i><span id="summary-phone"></span>
+                </div>
+                <div class="summary-item">
+                    <i class="fas fa-envelope"></i><span id="summary-email"></span>
+                </div>
+                <div class="summary-item">
+                    <i class="fas fa-map-marker-alt"></i><span id="summary-address"></span>
+                </div>
+                <div class="summary-item">
+                    <i class="fas fa-map"></i><span id="summary-state"></span>
+                </div>
+                <div class="summary-item">
+                    <i class="fas fa-city"></i><span id="summary-city"></span>
+                </div>
                 <div class="summary-item">
                     <i class="fas fa-gift"></i><span id="summary-overlay-gift"></span>
                 </div>


### PR DESCRIPTION
## Summary
- gather delivery email and save locally instead of sending WhatsApp immediately
- show confirmation overlay with buyer and shipping details before processing payment
- open WhatsApp with order summary only after successful purchase

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c6624b308324a343a43301a0af28