### PR TITLE
Add favicon and SEO metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,9 @@
     <meta name="keywords" content="smartphone, celular, tablet, iphone, samsung, xiaomi, accesorios, tecnología, latinoamérica">
     <link rel="icon" href="https://t4.ftcdn.net/jpg/03/39/21/23/360_F_339212336_B32VnQUYtef85KPoUedDJKlcmpIGwwTx.jpg" type="image/jpg">
     
+    <link rel="canonical" href="https://latinphone.com/">
+    <meta name="robots" content="index,follow">
+
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://latinphone.com/">

--- a/micuenta.html
+++ b/micuenta.html
@@ -5,6 +5,18 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
   <title>Mi Cuenta — Panel de Usuario</title>
   <meta name="description" content="Panel de control del cliente: pedidos, reclamos, seguimiento, seguros, facturas y más." />
+  <meta name="keywords" content="mi cuenta, panel de usuario, pedidos, seguimiento, latinphone" />
+  <link rel="icon" href="https://t4.ftcdn.net/jpg/03/39/21/23/360_F_339212336_B32VnQUYtef85KPoUedDJKlcmpIGwwTx.jpg" type="image/jpg" />
+  <link rel="canonical" href="https://latinphone.com/micuenta.html" />
+  <meta name="robots" content="index,follow" />
+
+  <!-- Open Graph / Facebook -->
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://latinphone.com/micuenta.html" />
+  <meta property="og:title" content="Mi Cuenta — Panel de Usuario" />
+  <meta property="og:description" content="Accede a tu panel para gestionar pedidos, reclamos, seguros y más en LatinPhone." />
+  <meta property="og:image" content="https://t4.ftcdn.net/jpg/03/39/21/23/360_F_339212336_B32VnQUYtef85KPoUedDJKlcmpIGwwTx.jpg" />
+
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">

--- a/pagos.html
+++ b/pagos.html
@@ -4,7 +4,19 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <title>Pasarela de Pago - LatinPhone</title>
-    
+    <meta name="description" content="Completa tu pedido con nuestra pasarela de pago segura para smartphones, tablets y accesorios LatinPhone.">
+    <meta name="keywords" content="pasarela de pago, checkout, latinphone, smartphones, tablets, accesorios">
+    <link rel="icon" href="https://t4.ftcdn.net/jpg/03/39/21/23/360_F_339212336_B32VnQUYtef85KPoUedDJKlcmpIGwwTx.jpg" type="image/jpg">
+    <link rel="canonical" href="https://latinphone.com/pagos.html">
+    <meta name="robots" content="index,follow">
+
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://latinphone.com/pagos.html">
+    <meta property="og:title" content="Pasarela de Pago - LatinPhone">
+    <meta property="og:description" content="Compra tecnología con envío a toda Latinoamérica mediante nuestra pasarela de pago segura.">
+    <meta property="og:image" content="https://t4.ftcdn.net/jpg/03/39/21/23/360_F_339212336_B32VnQUYtef85KPoUedDJKlcmpIGwwTx.jpg">
+
     <!-- Google Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
## Summary
- add canonical and robots meta tags to homepage
- provide favicon and SEO metadata for payment page
- include favicon and open graph SEO tags for account page

## Testing
- `npm test` *(fails: ENOENT Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1ca7e5b70832488331b0b31097462