### PR TITLE
Show success overlay after saving user info

### DIFF
--- a/pagos.css
+++ b/pagos.css
@@ -2594,6 +2594,43 @@
             width: 90%;
         }
 
+        /* Overlay de guardado exitoso */
+        .info-saved-overlay {
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: rgba(0, 0, 0, 0.4);
+            display: none;
+            align-items: center;
+            justify-content: center;
+            z-index: var(--z-overlay);
+        }
+
+        .info-saved-overlay.active {
+            display: flex;
+        }
+
+        .info-saved-modal {
+            background: var(--white);
+            padding: 3rem;
+            border-radius: var(--radius);
+            box-shadow: var(--shadow-lg);
+            text-align: center;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            animation: fadeIn 0.5s ease;
+        }
+
+        .info-saved-modal i {
+            font-size: 4rem;
+            color: var(--success-color);
+            margin-bottom: 1rem;
+            animation: pulse 1s ease;
+        }
+
         /* Overlay de selección de ubicación */
         .location-overlay {
             position: fixed;

--- a/pagos.html
+++ b/pagos.html
@@ -981,6 +981,14 @@
         </div>
     </div>
 
+    <!-- Overlay de guardado exitoso -->
+    <div class="info-saved-overlay" id="info-saved-overlay">
+        <div class="info-saved-modal">
+            <i class="fas fa-check-circle"></i>
+            <p>¡Información guardada con éxito!</p>
+        </div>
+    </div>
+
     <!-- Overlay de selección de ubicación -->
     <div class="location-overlay" id="location-overlay">
         <div class="location-modal">

--- a/pagos.js
+++ b/pagos.js
@@ -183,6 +183,7 @@
             const validationOverlay = document.getElementById('validation-overlay');
             const validationMessage = document.getElementById('validation-message');
             const validationClose = document.getElementById('validation-close');
+            const infoSavedOverlay = document.getElementById('info-saved-overlay');
             let zelleTimer;
 
             const locationOverlay = document.getElementById('location-overlay');
@@ -555,6 +556,14 @@
             const shippingCompanyInput = document.getElementById('shipping-company-input');
             let userInfoSaved = false;
 
+            function showInfoSavedOverlay() {
+                if (!infoSavedOverlay) return;
+                infoSavedOverlay.classList.add('active');
+                setTimeout(() => {
+                    infoSavedOverlay.classList.remove('active');
+                }, 2000);
+            }
+
             function saveUserInfo() {
                 const today = new Date().toISOString().slice(0,10);
                 const user = {
@@ -588,6 +597,7 @@
                     }
                     saveUserInfo();
                     showToast('success', 'Información guardada', 'Los datos se han almacenado correctamente.');
+                    showInfoSavedOverlay();
                 });
             }
 


### PR DESCRIPTION
## Summary
- display overlay with check animation when users save their information in payments page
- add styles and JavaScript logic to show and auto-hide overlay

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check pagos.js`


------
https://chatgpt.com/codex/tasks/task_e_68c1cc5f82c08324b2372d6655538eae