### PR TITLE
Add delayed WhatsApp handoff overlay after payment

### DIFF
--- a/pagos.css
+++ b/pagos.css
@@ -2509,6 +2509,38 @@
             justify-content: center;
         }
 
+        /* Overlay para enviar información a un operador */
+        .send-info-overlay {
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: rgba(0, 0, 0, 0.4);
+            display: none;
+            align-items: center;
+            justify-content: center;
+            z-index: var(--z-overlay);
+        }
+
+        .send-info-overlay.active {
+            display: flex;
+        }
+
+        .send-info-modal {
+            background: var(--white);
+            padding: 3rem;
+            border-radius: var(--radius);
+            box-shadow: var(--shadow-lg);
+            text-align: center;
+            max-width: 40rem;
+            width: 90%;
+        }
+
+        .send-info-modal button {
+            margin-top: 1.5rem;
+        }
+
         /* Overlay de resumen antes de pago */
         .summary-overlay {
             position: fixed;

--- a/pagos.html
+++ b/pagos.html
@@ -943,6 +943,15 @@
         </div>
     </div>
 
+    <!-- Overlay para envío de información -->
+    <div class="send-info-overlay" id="send-info-overlay">
+        <div class="send-info-modal">
+            <h3>Envío pendiente</h3>
+            <p>Debes enviar la información de tu compra a un operador de LatinPhone para gestionar el envío.</p>
+            <button class="btn btn-primary" id="send-info-accept">Aceptar</button>
+        </div>
+    </div>
+
     <!-- Overlay de acceso a cuenta -->
     <div class="account-overlay" id="account-overlay">
         <div class="account-modal">

--- a/pagos.js
+++ b/pagos.js
@@ -184,6 +184,8 @@
             const validationMessage = document.getElementById('validation-message');
             const validationClose = document.getElementById('validation-close');
             const infoSavedOverlay = document.getElementById('info-saved-overlay');
+            const sendInfoOverlay = document.getElementById('send-info-overlay');
+            const sendInfoAccept = document.getElementById('send-info-accept');
             let zelleTimer;
 
             const locationOverlay = document.getElementById('location-overlay');
@@ -2253,10 +2255,10 @@
                 // Notificar al usuario
                 showToast('success', '¡Compra exitosa!', 'Tu pago ha sido procesado correctamente.', 8000);
 
-                if (generatedWhatsappUrl) {
+                if (generatedWhatsappUrl && sendInfoOverlay) {
                     setTimeout(() => {
-                        window.open(generatedWhatsappUrl, '_blank');
-                    }, 500);
+                        sendInfoOverlay.classList.add('active');
+                    }, 30000);
                 }
             }
 
@@ -2671,6 +2673,15 @@
                 freeShippingCancel.addEventListener('click', () => {
                     freeShippingOverlay.classList.remove('active');
                     pendingShippingOption = null;
+                });
+            }
+
+            if (sendInfoOverlay && sendInfoAccept) {
+                sendInfoAccept.addEventListener('click', () => {
+                    sendInfoOverlay.classList.remove('active');
+                    if (generatedWhatsappUrl) {
+                        window.open(generatedWhatsappUrl, '_blank');
+                    }
                 });
             }
 


### PR DESCRIPTION
## Summary
- Show new overlay prompting users to send purchase info to LatinPhone via WhatsApp
- Delay overlay by 30s after successful payment to let success screen display
- Add supporting styles and event listeners for WhatsApp handoff

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1cdc1f9c88324b1779d31a33be2d9