### PR TITLE
Ocultar botón 'Mi cuenta' hasta primera compra

### DIFF
--- a/account.js
+++ b/account.js
@@ -12,14 +12,22 @@
         .forEach(k => localStorage.removeItem(k));
       return;
     }
+    const user = JSON.parse(localStorage.getItem('lpUser') || '{}');
+    const hasInfo = user.name && user.doc && user.phone;
+
     const link = document.getElementById('account-link');
     if(link){
       link.style.display = 'inline-block';
       link.classList && link.classList.remove('disabled');
       link.removeAttribute('aria-disabled');
-      const user = JSON.parse(localStorage.getItem('lpUser') || '{}');
-      const hasInfo = user.name && user.doc && user.phone;
       link.setAttribute('href', hasInfo ? 'micuenta.html' : 'informacion.html');
+    }
+
+    const btn = document.getElementById('account-btn');
+    if(btn){
+      btn.style.display = 'inline-block';
+      btn.setAttribute('href', hasInfo ? 'micuenta.html' : 'informacion.html');
+      btn.removeAttribute('aria-disabled');
     }
   });
 })();

--- a/index.html
+++ b/index.html
@@ -1029,7 +1029,7 @@
     <div class="product-list-section" id="productos">
         <a href="#" id="show-products-btn" class="products-button">Ver Listado Completo de Productos</a>
         <a href="venezuela.html" class="products-button">Zonas de Venezuela donde tenemos cobertura de entrega</a>
-        <a href="micuenta.html" class="products-button">Mi cuenta</a>
+        <a href="#" id="account-btn" class="products-button" style="display:none;" aria-disabled="true">Mi cuenta</a>
     </div>
 
     <div id="products-modal" class="product-modal">


### PR DESCRIPTION
## Summary
- Muestra el botón de "Mi cuenta" solo después de que exista una compra válida.
- Ajusta la lógica de `account.js` para habilitar tanto el enlace del menú como el botón inferior.

## Testing
- `npm test` *(falla: no existe package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d188a0008324bfdf1c9e70e55f62