### PR TITLE
fix: mostrar totales en confirmación de pago

### DIFF
--- a/pagos.js
+++ b/pagos.js
@@ -2232,7 +2232,14 @@
 
                 cart = cart.filter(item => !item.selected);
                 updateCartCount();
-                updateOrderSummary();
+
+                // Recuperar montos de la última orden para mantener los detalles en la confirmación
+                const orders = JSON.parse(localStorage.getItem('lpOrders') || '[]');
+                const currentOrder = orders.find(o => o.id === orderNumber) || orders[orders.length - 1];
+                if (currentOrder) {
+                    orderTotal.textContent = `$${Number(currentOrder.total).toFixed(2)}`;
+                    orderNationalization.textContent = `${Number(currentOrder.nationalizationFeeBs).toFixed(2)} Bs`;
+                }
 
                 // Pago exitoso, avanzar a la confirmación
                 goToStep(4);


### PR DESCRIPTION
## Summary
- Mantener los montos del pago y tasa de nacionalización en la pantalla de confirmación recuperando los valores de la última orden almacenada

## Testing
- `npm test` *(falla: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d4e1aa3c8324a1bae6dd703222af