### PR TITLE
feat: agregar botón volver en nacionalización

### DIFF
--- a/micuenta.html
+++ b/micuenta.html
@@ -1192,6 +1192,11 @@
         window.location.href = './informacion.html';
         return;
       }
+      if(localStorage.getItem('lpAccountBypass') === 'true'){
+        localStorage.removeItem('lpAccountBypass');
+        init();
+        return;
+      }
       const form = document.getElementById('loginForm');
       const input = document.getElementById('cedInput');
       const error = document.getElementById('loginError');

--- a/na.html
+++ b/na.html
@@ -105,9 +105,12 @@
             <div class="badge" id="orderBadge"></div>
           </div>
         </div>
-        <div class="carrier">
-          <span class="help">Transporte</span>
-          <span id="carrierName"></span>
+        <div style="display:flex;align-items:center;gap:12px">
+          <div class="carrier">
+            <span class="help">Transporte</span>
+            <span id="carrierName"></span>
+          </div>
+          <button id="backBtn" class="btn muted">Volver</button>
         </div>
       </header>
 
@@ -358,6 +361,15 @@
       s.style.animationDelay = (Math.random()*0.6)+'s';
       confettiBox.appendChild(s);
     }
+  }
+
+  // Botón Volver a Mi Cuenta
+  const backBtn = document.getElementById('backBtn');
+  if(backBtn){
+    backBtn.addEventListener('click', () => {
+      localStorage.setItem('lpAccountBypass', 'true');
+      window.location.href = 'micuenta.html';
+    });
   }
 
   // Aviso de nacionalización con conteo regresivo


### PR DESCRIPTION
## Summary
- add "Volver" button on the nationalization payment page
- skip cedula verification when returning to Mi Cuenta via the new button

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d50f5a8083249af559d8db847b94