### PR TITLE
feat: sync tracking with user data

### DIFF
--- a/miseguimiento.html
+++ b/miseguimiento.html
@@ -213,7 +213,7 @@
           <div class="id">
             <span class="pill">Orden: <b data-id="orderId">LP-X9D8NVWE</b></span>
             <span class="pill" id="customerNameWrap" style="display:none;">Cliente: <b id="customerName"></b></span>
-            <span class="pill paid">Todo pago ✓</span>
+            <span class="pill" id="nationalizationStatus"></span>
           </div>
         </div>
       </div>
@@ -227,10 +227,7 @@
         <h3>Estado y progreso</h3>
         <div class="row" style="align-items:center; gap:10px">
           <div>Entrega estimada: <span class="strong" id="eta"></span></div>
-          <div class="logos" style="margin-left:auto">
-            <div class="dhl" title="Courier internacional">DHL</div>
-            <img src="https://libertyexpress.com/wp-content/themes/kutis/assets/svg/logo_banner.svg" alt="Liberty Express" title="Courier local">
-          </div>
+          <div class="logos" style="margin-left:auto" id="courierLogos"></div>
         </div>
         <div class="progress" title="Progreso del envío">
           <div class="bar" id="bar"></div>
@@ -243,7 +240,7 @@
         <div class="map" aria-label="Ruta ilustrativa Doral → Caracas → Acarigua">
           <div class="city doral"><div class="pt"></div><span>Doral, FL</span></div>
           <div class="city caracas"><div class="pt"></div><span>Caracas (CCS)</span></div>
-          <div class="city acarigua"><div class="pt"></div><span>Acarigua</span></div>
+          <div class="city dest"><div class="pt"></div><span id="destCityLabel">Acarigua</span></div>
           <svg viewBox="0 0 1000 240" preserveAspectRatio="none" aria-hidden="true">
             <defs>
               <linearGradient id="g" x1="0%" y1="0%" x2="100%" y2="0%">
@@ -269,7 +266,7 @@
         <div class="facts">
           <div class="row"><div class="kv">Estado</div><div class="val" id="stateTxt">Calculando...</div></div>
           <div class="row"><div class="kv">Courier internacional</div><div class="val">DHL • <a id="dhlAwbLink" target="_blank"><span id="dhlAwb"></span></a></div></div>
-          <div class="row"><div class="kv">Courier local</div><div class="val">Liberty Express</div></div>
+          <div class="row"><div class="kv">Courier local</div><div class="val" id="localCourier"></div></div>
           <div class="row"><div class="kv">Origen</div><div class="val">Doral, Florida (USA)</div></div>
           <div class="row"><div class="kv">Destino final</div><div class="val" id="finalDest"></div></div>
           <div class="row"><div class="kv">Retiro</div><div class="val">Solo titular con cédula</div></div>
@@ -285,7 +282,7 @@
     </section>
 
     <footer class="footnote" style="margin-top:16px; text-align:center">
-      LatinPhone • Envíos Doral → Venezuela con DHL & Liberty • © 2025
+      LatinPhone • Envíos Doral → Venezuela con DHL & <span id="footerCourier">Liberty</span> • © 2025
     </footer>
   </div>
 
@@ -294,7 +291,22 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const orders = JSON.parse(localStorage.getItem('lpOrders') || '[]');
   const user = JSON.parse(localStorage.getItem('lpUser') || '{}');
+  const addresses = JSON.parse(localStorage.getItem('lpAddresses') || '[]');
   const latestOrder = orders[orders.length - 1];
+  const nationalizationDone = localStorage.getItem('lpNationalizationDone') === 'true';
+
+  const defaultAddress = addresses.find(a => a.default) || addresses[0] || {};
+  const courierMap = {
+    liberty: { name: 'Liberty Express', logo: 'https://libertyexpress.com/wp-content/themes/kutis/assets/svg/logo_banner.svg', code: 'liberty' },
+    mrw: { name: 'MRW', logo: 'https://upload.wikimedia.org/wikipedia/commons/thumb/2/26/MRW_logo.svg/477px-MRW_logo.svg.png', code: 'mrw' },
+    zoom: { name: 'ZOOM', logo: 'https://upload.wikimedia.org/wikipedia/commons/7/71/Grupo_ZOOM_logo.png?20211116211646', code: 'zoom' },
+    tealca: { name: 'TEALCA', logo: 'https://www.tealca.es/wp-content/uploads/logo.png', code: 'tealca' },
+    dhl: { name: 'DHL', logo: 'https://www.logo.wine/a/logo/DHL/DHL-Logo.wine.svg', code: 'dhl' },
+    fedex: { name: 'FedEx', logo: 'https://www.logo.wine/a/logo/FedEx_Express/FedEx_Express-Logo.wine.svg', code: 'fedex' }
+  };
+
+  const courierCode = (latestOrder && latestOrder.shipping && latestOrder.shipping.courier || '').toLowerCase();
+  const localCourier = courierMap[courierCode] || courierMap.liberty;
 
   // ====== 1. DATOS DEL ENVÍO (Puedes editar aquí) ======
   const defaultSteps = [
@@ -302,19 +314,20 @@ document.addEventListener('DOMContentLoaded', () => {
       { date: "2025-09-07T17:40:00Z", title: "Recibido en almacén", meta: "Doral, FL", courier: "LATINPHONE" },
       { date: "2025-09-08T03:20:00Z", title: "Salida de centro de clasificación", meta: "DHL • Miami Hub", courier: "DHL" },
       { date: "2025-09-09T12:10:00Z", title: "Arribo a Venezuela (CCS)", meta: "DHL • Caracas", courier: "DHL" },
-      { date: "2025-09-09T18:00:00Z", title: "Traspaso de courier", meta: "DHL → Liberty Express", courier: "LIBERTY" },
-      { date: "2025-09-10T14:45:00Z", title: "En ruta a sucursal", meta: "Liberty • Acarigua", courier: "LIBERTY" },
-      { date: "2025-09-10T21:00:00Z", title: "Listo para retiro", meta: `Liberty — ${"C.C. Rupica"}`, courier: "LIBERTY" }
+      { date: "2025-09-09T18:00:00Z", title: "Traspaso de courier", meta: `DHL → ${localCourier.name}`, courier: localCourier.name.toUpperCase() },
+      { date: "2025-09-10T14:45:00Z", title: "En ruta a destino", meta: `${localCourier.name} • ${defaultAddress.city || ''}`, courier: localCourier.name.toUpperCase() },
+      { date: "2025-09-10T21:00:00Z", title: "Listo para retiro", meta: `${localCourier.name} — ${defaultAddress.city || ''}`, courier: localCourier.name.toUpperCase() }
   ];
 
   const data = {
     orderId: "LP-X9D8NVWE",
-    paid: true,
+    paid: nationalizationDone,
     purchaseUTC: "2025-09-07T13:00:00Z",
     etaUTC: "2025-09-10T21:00:00Z",
     dhlAwb: "9876 4521 309",
     handoffUTC: "2025-09-09T18:00:00Z",
-    libertyBranch: "C.C. Rupica, Acarigua",
+    destCity: defaultAddress.city || 'Acarigua',
+    courierLocal: localCourier,
     steps: defaultSteps
   };
 
@@ -324,6 +337,8 @@ document.addEventListener('DOMContentLoaded', () => {
     if (latestOrder.shipping) {
       data.etaUTC = latestOrder.shipping.eta ? new Date(latestOrder.shipping.eta).toISOString() : data.etaUTC;
       if (latestOrder.shipping.tracking) data.dhlAwb = latestOrder.shipping.tracking;
+      const shippingCourier = (latestOrder.shipping.courier || '').toLowerCase();
+      if (courierMap[shippingCourier]) data.courierLocal = courierMap[shippingCourier];
       if (latestOrder.shipping.steps && latestOrder.shipping.steps.length) {
         const userSteps = latestOrder.shipping.steps.map(s => ({
           date: s.when.includes('T') ? s.when + 'Z' : s.when.replace(' ', 'T') + 'Z',
@@ -355,6 +370,12 @@ document.addEventListener('DOMContentLoaded', () => {
     customerNameWrap: document.getElementById('customerNameWrap'),
     customerName: document.getElementById('customerName'),
     dhlAwbLink: document.getElementById('dhlAwbLink'),
+    logos: document.getElementById('courierLogos'),
+    localCourier: document.getElementById('localCourier'),
+    destCityLabel: document.getElementById('destCityLabel'),
+    nationalizationStatus: document.getElementById('nationalizationStatus'),
+    map: document.querySelector('.map'),
+    footerCourier: document.getElementById('footerCourier')
   };
 
   // ====== 3. UTILIDADES (Formateo de fechas) ======
@@ -389,12 +410,29 @@ document.addEventListener('DOMContentLoaded', () => {
       const awbClean = data.dhlAwb.replace(/\s+/g, '');
       DOMElements.dhlAwbLink.href = `https://www.dhl.com/global-en/home/tracking/tracking-express.html?submit=1&tracking-id=${encodeURIComponent(awbClean)}`;
     }
-    DOMElements.finalDest.textContent = `Liberty Express — ${data.libertyBranch}`;
+    DOMElements.localCourier.textContent = data.courierLocal.name;
+    DOMElements.finalDest.textContent = `${data.courierLocal.name} — ${data.destCity}`;
+    DOMElements.destCityLabel.textContent = data.destCity;
+    if (DOMElements.map) DOMElements.map.setAttribute('aria-label', `Ruta ilustrativa Doral → Caracas → ${data.destCity}`);
+    let logos = '';
+    if (data.courierLocal.code !== 'dhl') logos += '<div class="dhl" title="Courier internacional">DHL</div>';
+    logos += `<img src="${data.courierLocal.logo}" alt="${data.courierLocal.name}" title="Courier local">`;
+    DOMElements.logos.innerHTML = logos;
+    if (DOMElements.nationalizationStatus) {
+      if (data.paid) {
+        DOMElements.nationalizationStatus.textContent = 'Todo pago ✓';
+        DOMElements.nationalizationStatus.classList.add('paid');
+      } else {
+        DOMElements.nationalizationStatus.textContent = 'Nacionalización pendiente';
+        DOMElements.nationalizationStatus.classList.remove('paid');
+      }
+    }
+    if (DOMElements.footerCourier) DOMElements.footerCourier.textContent = data.courierLocal.name;
 
     // Renderizar Timeline (estructura)
     DOMElements.timeline.innerHTML = data.steps.map((s, i) => {
-      const courierName = s.courier === 'DHL' ? 'DHL' : s.courier === 'LIBERTY' ? 'Liberty Express' : 'LatinPhone';
-      const chipClass = s.courier === 'DHL' ? 'dhl' : s.courier === 'LIBERTY' ? 'lib' : '';
+      const courierName = s.courier === 'DHL' ? 'DHL' : s.courier === data.courierLocal.name.toUpperCase() ? data.courierLocal.name : 'LatinPhone';
+      const chipClass = s.courier === 'DHL' ? 'dhl' : (s.courier === 'LIBERTY' ? 'lib' : '');
       return `
         <div class="step" data-step-date="${s.date}">
           <div class="dot"></div>
@@ -408,7 +446,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // Renderizar Tabla de Eventos
     DOMElements.eventsTbody.innerHTML = [...data.steps].reverse().map(s => {
-      const courierName = s.courier === 'DHL' ? 'DHL' : s.courier === 'LIBERTY' ? 'Liberty Express' : 'LatinPhone';
+      const courierName = s.courier === 'DHL' ? 'DHL' : s.courier === data.courierLocal.name.toUpperCase() ? data.courierLocal.name : 'LatinPhone';
       return `
         <tr>
           <td>${fmt(s.date)}</td>
@@ -452,7 +490,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (delivered) {
       DOMElements.stateTxt.textContent = 'Listo para retiro';
     } else if (now >= new Date(data.handoffUTC)) {
-      DOMElements.stateTxt.textContent = 'Con Liberty Express';
+      DOMElements.stateTxt.textContent = `Con ${data.courierLocal.name}`;
     } else {
       DOMElements.stateTxt.textContent = 'En tránsito con DHL';
     }


### PR DESCRIPTION
## Summary
- update tracking page to reflect nationalization payment status
- show selected courier and destination city using local storage

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d77c76f88324956b71e1d8d15f08