### PR TITLE
feat: agregar botón de anulación de compra

### DIFF
--- a/micuenta.html
+++ b/micuenta.html
@@ -155,6 +155,8 @@
     .badge.soon{color:#2563EB;border-color:#BFDBFE;background:#EFF6FF}
     .progress{height:8px;background:#E5E7EB;border-radius:999px;overflow:hidden}
     .progress > span{display:block;height:100%;background:linear-gradient(90deg,#60A5FA,#2563EB)}
+    @keyframes spin{to{transform:rotate(360deg)}}
+    .spinner{width:40px;height:40px;border:4px solid var(--line);border-top-color:var(--primary);border-radius:50%;animation:spin 1s linear infinite;margin:20px auto}
     /* Modales */
     .modal{position:fixed;inset:0;background:rgba(0,0,0,.25);display:none;align-items:center;justify-content:center;padding:16px;z-index:50}
     .modal.open{display:flex}
@@ -237,6 +239,7 @@
         <div class="toolbar">
           <button class="btn ghost" id="refreshBtn">Actualizar</button>
           <button class="btn ghost" id="exportBtn">Exportar datos</button>
+          <button class="btn danger" id="cancelBtn">Anular compra</button>
         </div>
       </div>
       <div class="content-body" id="viewContent">
@@ -290,6 +293,15 @@
         <button class="close-x" data-close-modal="modalTicket" aria-label="Cerrar">×</button>
       </div>
       <div class="panel-body" id="modalTicketBody"></div>
+    </div>
+  </section>
+
+  <section class="modal" id="modalProcessing" aria-modal="true" role="alertdialog">
+    <div class="panel" style="max-width:320px;text-align:center">
+      <div class="panel-body">
+        <div class="spinner" aria-hidden="true"></div>
+        <p>Procesando...</p>
+      </div>
     </div>
   </section>
 
@@ -1125,6 +1137,21 @@
       showMessage('Preferencias guardadas (demo).');
     }
 
+    function cancelPurchase(){
+      if(confirm('¿Deseas anular la compra y devolver los fondos a tu tarjeta de crédito?')){
+        if(confirm('Confirma que los fondos sean regresados a la tarjeta X3009 VISA.')){
+          openModal('modalProcessing');
+          setTimeout(()=>{
+            closeModal('modalProcessing');
+            showMessage('El dinero estará de regreso en la tarjeta X3009 VISA en los próximos 5 días. Por favor abstente de realizar cualquier operación o pago. Toda tu información ha sido eliminada.', ()=>{
+              localStorage.clear();
+              window.location.href = './index.html';
+            });
+          },3000);
+        }
+      }
+    }
+
     /** Modales **/
     function openModal(id){ const m = document.getElementById(id); if(m) m.classList.add('open'); }
     function closeModal(id){ const m = document.getElementById(id); if(m) m.classList.remove('open'); }
@@ -1157,6 +1184,7 @@
       });
       $('#refreshBtn').addEventListener('click', ()=> render());
       $('#exportBtn').addEventListener('click', exportData);
+      $('#cancelBtn').addEventListener('click', cancelPurchase);
       $('#logoutBtn').addEventListener('click', ()=> {
         showMessage('Sesión cerrada (demo).', ()=>{
         // Limpieza mínima manteniendo datos: simular logout redirigiendo


### PR DESCRIPTION
## Summary
- añadir botón rojo **Anular compra** con confirmaciones de cancelación y tarjeta X3009 VISA
- mostrar animación de proceso y borrar información del usuario tras la cancelación

## Testing
- `npm test` *(falla: package.json no encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d8cb062c83248e39d94357468740