### PR TITLE
Enforce nationalization payment workflow across pages

### DIFF
--- a/account.js
+++ b/account.js
@@ -4,6 +4,15 @@
     const addresses = JSON.parse(localStorage.getItem('lpAddresses') || '[]');
     const invoices = JSON.parse(localStorage.getItem('lpInvoices') || '[]');
     if(!orders.length || !addresses.length || !invoices.length) return;
+
+    const pendingNat = localStorage.getItem('lpPendingNationalization');
+    const natDone = localStorage.getItem('lpNationalizationDone') === 'true';
+    if(pendingNat && !natDone &&
+       !location.pathname.endsWith('na.html') &&
+       !location.pathname.endsWith('micuenta.html')){
+      window.location.href = 'na.html';
+      return;
+    }
     const lastOrder = orders[orders.length - 1];
     const eta = lastOrder.shipping && lastOrder.shipping.eta;
     const today = new Date().toISOString().slice(0,10);

--- a/mifactura.html
+++ b/mifactura.html
@@ -4,6 +4,14 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>Factura Digital - LatinPhone - LP-X9D8NVWE</title>
+<script>
+  const pendingNat = localStorage.getItem('lpPendingNationalization');
+  const natDoneFlag = localStorage.getItem('lpNationalizationDone') === 'true';
+  if(pendingNat && !natDoneFlag){
+    localStorage.setItem('lpAccountBypass','true');
+    window.location.href = 'na.html';
+  }
+</script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">

--- a/miseguimiento.html
+++ b/miseguimiento.html
@@ -4,6 +4,14 @@
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"/>
 <title>Tracking en Vivo — LatinPhone • LP-X9D8NVWE</title>
+<script>
+  const pendingNat = localStorage.getItem('lpPendingNationalization');
+  const natDone = localStorage.getItem('lpNationalizationDone') === 'true';
+  if(pendingNat && !natDone){
+    localStorage.setItem('lpAccountBypass','true');
+    window.location.href = 'na.html';
+  }
+</script>
 <meta name="color-scheme" content="light">
 <style>
   :root {

--- a/na.html
+++ b/na.html
@@ -4,6 +4,14 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>Pago de Nacionalización</title>
+<script>
+  var pending = JSON.parse(localStorage.getItem('lpPendingNationalization') || 'null');
+  var natDone = localStorage.getItem('lpNationalizationDone') === 'true';
+  if(!pending || natDone){
+    localStorage.setItem('lpAccountBypass', 'true');
+    window.location.href = 'micuenta.html';
+  }
+</script>
 <style>
   :root{
     --primary:#0b5fff; --ink:#1a1f36; --muted:#6b7280;
@@ -243,7 +251,6 @@
   </div>
 
 <script>
-  const pending = JSON.parse(localStorage.getItem('lpPendingNationalization') || 'null');
   const user = JSON.parse(localStorage.getItem('lpUser') || '{}');
   const fmtBs = new Intl.NumberFormat('es-VE',{style:'currency',currency:'VES'});
   let orderId = pending ? pending.orderId : '';


### PR DESCRIPTION
## Summary
- Redirect users to nationalization payment page when a pending nationalization fee exists.
- Lock nationalization page once the proof is uploaded and ensure other pages respect payment status.
- Prevent access to tracking and invoice pages until nationalization payment is reported.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d9cb59048324a7b0e63333d3d98a