### PR TITLE
Add product images for select electronics

### DIFF
--- a/pagos.js
+++ b/pagos.js
@@ -942,18 +942,18 @@
                 },
                 televisores: {
                     samsung: [
-                        { id: 'samsungtv55', name: 'Samsung TV 55" QLED Google TV', price: 415, specs: ['QLED', '4K UHD', 'Google TV'] },
-                        { id: 'samsungtv65', name: 'Samsung TV 65" QLED HDR+', price: 645, specs: ['QLED', '4K UHD', 'HDR+'] }
+                        { id: 'samsungtv55', name: 'Samsung TV 55" QLED Google TV', price: 415, specs: ['QLED', '4K UHD', 'Google TV'], image: 'https://thumb.pccomponentes.com/w-530-530/articles/1084/10843920/1598-samsung-tq65q60dauxxc-65-qled-ultrahd-4k-hdr10-tizen.jpg' },
+                        { id: 'samsungtv65', name: 'Samsung TV 65" QLED HDR+', price: 645, specs: ['QLED', '4K UHD', 'HDR+'], image: 'https://thumb.pccomponentes.com/w-530-530/articles/1084/10843920/1598-samsung-tq65q60dauxxc-65-qled-ultrahd-4k-hdr10-tizen.jpg' }
                     ],
                     tcl: [
-                        { id: 'tcltv43', name: 'TCL 43" HDR Android TV', price: 225, specs: ['LED', '4K UHD', 'Android TV'] },
-                        { id: 'tcltv55', name: 'TCL 55" QLED HDR+ Google TV', price: 415, specs: ['QLED', '4K UHD', 'Google TV'] }
+                        { id: 'tcltv43', name: 'TCL 43" HDR Android TV', price: 225, specs: ['LED', '4K UHD', 'Android TV'], image: 'https://thumb.pccomponentes.com/w-530-530/articles/1087/10878902/1333-tcl-qled-43-43p7k-ultrahd-4k-dolby-atmos-google-tv.jpg' },
+                        { id: 'tcltv55', name: 'TCL 55" QLED HDR+ Google TV', price: 415, specs: ['QLED', '4K UHD', 'Google TV'], image: 'https://thumb.pccomponentes.com/w-530-530/articles/1063/10635665/1219-tcl-55c631-55-qled-ultrahd-4k-hdr10.jpg' }
                     ]
                 },
                 videojuegos: {
                     nintendo: [
-                        { id: 'switcholed', name: 'Nintendo Switch Oled', price: 330, specs: ['Pantalla OLED 7"', 'Almacenamiento 64GB', 'Dock con puerto LAN'] },
-                        { id: 'switchlite', name: 'Nintendo Switch Lite', price: 190, specs: ['Portátil', 'Almacenamiento 32GB', 'Compatibilidad con juegos Switch'] }
+                        { id: 'switcholed', name: 'Nintendo Switch Oled', price: 330, specs: ['Pantalla OLED 7"', 'Almacenamiento 64GB', 'Dock con puerto LAN'], image: 'https://media.ldlc.com/r705/ld/products/00/05/95/95/LD0005959596.jpg' },
+                        { id: 'switchlite', name: 'Nintendo Switch Lite', price: 190, specs: ['Portátil', 'Almacenamiento 32GB', 'Compatibilidad con juegos Switch'], image: 'https://media.ldlc.com/r705/ld/products/00/05/97/96/LD0005979676.jpg' }
                     ],
                     sony: [
                         { id: 'ps5slim', name: 'PS5 Slim Disco', price: 610, specs: ['SSD 1TB', 'Ray Tracing', '4K a 120fps'] },
@@ -966,7 +966,7 @@
                 },
                 pc: {
                     hp: [
-                        { id: 'hp1355u', name: 'HP I7 1355U 16GB/1TB', price: 720, specs: ['I7 1355U', '16GB RAM', '1TB SSD', 'Pantalla 15.6"', 'Windows 11 + Office'] }
+                        { id: 'hp1355u', name: 'HP I7 1355U 16GB/1TB', price: 720, specs: ['I7 1355U', '16GB RAM', '1TB SSD', 'Pantalla 15.6"', 'Windows 11 + Office'], image: 'https://thumb.pccomponentes.com/w-530-530/articles/1081/10812087/1333-hp-15-fd0011ns-intel-core-i7-1355u-16gb-1tb-ssd-156.jpg' }
                     ]
                 }
             };

--- a/pagos1.html
+++ b/pagos1.html
@@ -3896,7 +3896,7 @@
                     apple: [
                         { id: 'ipadair', name: 'iPad Air 11" M2 128GB', price: 650, specs: ['Chip M2', '128GB', 'Pantalla 11"'] },
                         { id: 'ipadpro', name: 'iPad Pro 11" M4 256GB', price: 1030, specs: ['Chip M4', '256GB', 'Pantalla 11"'] },
-                        { id: 'HP I7 1355U', name: 'HP I7 1355U" 16 1TB', price: 800, specs: ['I7 1355U', '1TB', 'Pantalla 15.6 WIN11+OFFICE"'] }
+                        { id: 'HP I7 1355U', name: 'HP I7 1355U" 16 1TB', price: 800, specs: ['I7 1355U', '1TB', 'Pantalla 15.6 WIN11+OFFICE"'], image: 'https://thumb.pccomponentes.com/w-530-530/articles/1081/10812087/1333-hp-15-fd0011ns-intel-core-i7-1355u-16gb-1tb-ssd-156.jpg' }
                     ],
                     samsung: [
                         { id: 'samsungtaba9', name: 'Samsung Tab A9 X110 4/64GB', price: 125, specs: ['4GB RAM', '64GB', 'Pantalla 8.7"'] },
@@ -3935,18 +3935,18 @@
                 },
                 televisores: {
                     samsung: [
-                        { id: 'samsungtv55', name: 'Samsung TV 55" QLED Google TV', price: 415, specs: ['QLED', '4K UHD', 'Google TV'] },
-                        { id: 'samsungtv65', name: 'Samsung TV 65" QLED HDR+', price: 645, specs: ['QLED', '4K UHD', 'HDR+'] }
+                        { id: 'samsungtv55', name: 'Samsung TV 55" QLED Google TV', price: 415, specs: ['QLED', '4K UHD', 'Google TV'], image: 'https://thumb.pccomponentes.com/w-530-530/articles/1084/10843920/1598-samsung-tq65q60dauxxc-65-qled-ultrahd-4k-hdr10-tizen.jpg' },
+                        { id: 'samsungtv65', name: 'Samsung TV 65" QLED HDR+', price: 645, specs: ['QLED', '4K UHD', 'HDR+'], image: 'https://thumb.pccomponentes.com/w-530-530/articles/1084/10843920/1598-samsung-tq65q60dauxxc-65-qled-ultrahd-4k-hdr10-tizen.jpg' }
                     ],
                     tcl: [
-                        { id: 'tcltv43', name: 'TCL 43" HDR Android TV', price: 225, specs: ['LED', '4K UHD', 'Android TV'] },
-                        { id: 'tcltv55', name: 'TCL 55" QLED HDR+ Google TV', price: 415, specs: ['QLED', '4K UHD', 'Google TV'] }
+                        { id: 'tcltv43', name: 'TCL 43" HDR Android TV', price: 225, specs: ['LED', '4K UHD', 'Android TV'], image: 'https://thumb.pccomponentes.com/w-530-530/articles/1087/10878902/1333-tcl-qled-43-43p7k-ultrahd-4k-dolby-atmos-google-tv.jpg' },
+                        { id: 'tcltv55', name: 'TCL 55" QLED HDR+ Google TV', price: 415, specs: ['QLED', '4K UHD', 'Google TV'], image: 'https://thumb.pccomponentes.com/w-530-530/articles/1063/10635665/1219-tcl-55c631-55-qled-ultrahd-4k-hdr10.jpg' }
                     ]
                 },
                 videojuegos: {
                     nintendo: [
-                        { id: 'switcholed', name: 'Nintendo Switch Oled', price: 330, specs: ['Pantalla OLED 7"', 'Almacenamiento 64GB', 'Dock con puerto LAN'] },
-                        { id: 'switchlite', name: 'Nintendo Switch Lite', price: 190, specs: ['Portátil', 'Almacenamiento 32GB', 'Compatibilidad con juegos Switch'] }
+                        { id: 'switcholed', name: 'Nintendo Switch Oled', price: 330, specs: ['Pantalla OLED 7"', 'Almacenamiento 64GB', 'Dock con puerto LAN'], image: 'https://media.ldlc.com/r705/ld/products/00/05/95/95/LD0005959596.jpg' },
+                        { id: 'switchlite', name: 'Nintendo Switch Lite', price: 190, specs: ['Portátil', 'Almacenamiento 32GB', 'Compatibilidad con juegos Switch'], image: 'https://media.ldlc.com/r705/ld/products/00/05/97/96/LD0005979676.jpg' }
                     ],
                     sony: [
                         { id: 'ps5slim', name: 'PS5 Slim Disco', price: 610, specs: ['SSD 1TB', 'Ray Tracing', '4K a 120fps'] },


### PR DESCRIPTION
## Summary
- include image URLs for HP I7 1355U, Nintendo Switch models and Samsung/TCL TVs in product data

## Testing
- `node --check pagos.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1f2a217e08324978c1826507b46e8