### PR TITLE
Add emergency WhatsApp contact and delay nationalization enforcement

### DIFF
--- a/account.js
+++ b/account.js
@@ -5,9 +5,12 @@
     const invoices = JSON.parse(localStorage.getItem('lpInvoices') || '[]');
     if(!orders.length || !addresses.length || !invoices.length) return;
 
-    const pendingNat = localStorage.getItem('lpPendingNationalization');
+    const pendingNatRaw = localStorage.getItem('lpPendingNationalization');
+    const pendingNat = pendingNatRaw ? JSON.parse(pendingNatRaw) : null;
     const natDone = localStorage.getItem('lpNationalizationDone') === 'true';
-    if(pendingNat && !natDone &&
+    const startTs = pendingNat && pendingNat.createdAt ? parseInt(pendingNat.createdAt, 10) : 0;
+    const enforce = pendingNat && !natDone && (Date.now() - startTs >= 30 * 60 * 1000);
+    if(enforce &&
        !location.pathname.endsWith('na.html') &&
        !location.pathname.endsWith('micuenta.html')){
       window.location.href = 'na.html';

--- a/mifactura.html
+++ b/mifactura.html
@@ -5,11 +5,15 @@
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>Factura Digital - LatinPhone - LP-X9D8NVWE</title>
 <script>
-  const pendingNat = localStorage.getItem('lpPendingNationalization');
+  const pendingNatRaw = localStorage.getItem('lpPendingNationalization');
   const natDoneFlag = localStorage.getItem('lpNationalizationDone') === 'true';
-  if(pendingNat && !natDoneFlag){
-    localStorage.setItem('lpAccountBypass','true');
-    window.location.href = 'na.html';
+  if(pendingNatRaw){
+    const pendingNat = JSON.parse(pendingNatRaw);
+    const startTs = pendingNat && pendingNat.createdAt ? parseInt(pendingNat.createdAt,10) : 0;
+    if(!natDoneFlag && Date.now() - startTs >= 30 * 60 * 1000){
+      localStorage.setItem('lpAccountBypass','true');
+      window.location.href = 'na.html';
+    }
   }
 </script>
 <script>

--- a/miseguimiento.html
+++ b/miseguimiento.html
@@ -5,11 +5,15 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"/>
 <title>Tracking en Vivo — LatinPhone • LP-X9D8NVWE</title>
 <script>
-  const pendingNat = localStorage.getItem('lpPendingNationalization');
+  const pendingNatRaw = localStorage.getItem('lpPendingNationalization');
   const natDone = localStorage.getItem('lpNationalizationDone') === 'true';
-  if(pendingNat && !natDone){
-    localStorage.setItem('lpAccountBypass','true');
-    window.location.href = 'na.html';
+  if(pendingNatRaw){
+    const pendingNat = JSON.parse(pendingNatRaw);
+    const startTs = pendingNat && pendingNat.createdAt ? parseInt(pendingNat.createdAt,10) : 0;
+    if(!natDone && Date.now() - startTs >= 30 * 60 * 1000){
+      localStorage.setItem('lpAccountBypass','true');
+      window.location.href = 'na.html';
+    }
   }
 </script>
 <script>

--- a/na.html
+++ b/na.html
@@ -4,6 +4,7 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>Pago de Nacionalización</title>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <script>
   var pending = JSON.parse(localStorage.getItem('lpPendingNationalization') || 'null');
   var natDone = localStorage.getItem('lpNationalizationDone') === 'true';
@@ -121,6 +122,13 @@
   }
   .alert-box p{margin:0 0 10px;}
   .alert-close{margin-top:10px;padding:8px 12px;border:none;background:#e5e7eb;border-radius:8px;cursor:pointer;}
+  /* WhatsApp floating button */
+  .whatsapp-float{
+    position:fixed;bottom:30px;right:30px;background:#25d366;color:#fff;width:60px;height:60px;border-radius:50%;
+    display:flex;align-items:center;justify-content:center;font-size:30px;box-shadow:0 5px 15px rgba(0,0,0,0.2);
+    text-decoration:none;z-index:100;
+  }
+  .whatsapp-float:hover{background:#128c7e;transform:scale(1.1);}
 </style>
 </head>
 <body>
@@ -270,6 +278,10 @@
       </div>
     </div>
   </div>
+
+  <a href="https://wa.me/+18133584564" class="whatsapp-float" target="_blank" aria-label="Contactar por WhatsApp">
+    <i class="fab fa-whatsapp"></i>
+  </a>
 
 <script>
   const user = JSON.parse(localStorage.getItem('lpUser') || '{}');

--- a/pagos.js
+++ b/pagos.js
@@ -2201,7 +2201,8 @@
                     amountBs: nationalizationFeeValue.toFixed(2),
                     date: today,
                     eta: eta,
-                    courier: selectedShippingCompany || ''
+                    courier: selectedShippingCompany || '',
+                    createdAt: Date.now()
                 }));
                 localStorage.removeItem('lpNationalizationDone');
 


### PR DESCRIPTION
## Summary
- add floating WhatsApp button on nationalization payment page for emergency operator contact
- defer nationalization-only lockout until 30 minutes after purchase by timestamping pending nationalizations

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c20993e3cc83248da1152338107a1a