### PR TITLE
Remove fixed product images from pagos page

### DIFF
--- a/pagos.html
+++ b/pagos.html
@@ -136,13 +136,6 @@
                 </div>
             </div>
 
-            <div class="tablet-gallery">
-                <img src="https://media.ldlc.com/r705/ld/products/00/06/10/31/LD0006103138.jpg" alt="Samsung Tab A9 X110">
-                <img src="https://media.ldlc.com/r705/ld/products/00/06/17/44/LD0006174463_0006174582.jpg" alt="Samsung Tab S10 Plus X820 12/256GB">
-                <img src="https://media.ldlc.com/r705/ld/products/00/06/27/24/LD0006272462_0006272467.jpg" alt="Samsung Tab S11 X910 12/256GB">
-                <img src="https://media.ldlc.com/r705/ld/products/00/06/27/24/LD0006272422_0006272442.jpg" alt="Samsung Tab S11 Ultra X916 16/512GB">
-            </div>
-
             <div id="step-country" class="wizard-step active">
                 <h2 class="section-title"><i class="fas fa-globe-americas"></i> Selecciona tu país</h2>
                     <div class="country-grid">


### PR DESCRIPTION
## Summary
- remove static tablet gallery images from the payments page so only the country selector is shown

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68c26907bac48324a20087fa13ae18f3