### PR TITLE
Extiende animación de procesamiento a 6 segundos

### DIFF
--- a/pagos.js
+++ b/pagos.js
@@ -2119,10 +2119,12 @@
                     accountLink.setAttribute('href', hasInfo ? 'micuenta.html' : 'informacion.html');
                 }
 
+            // Simula el tiempo de procesamiento del pago.
+            // Se amplió a 6 segundos para una experiencia de usuario más realista.
             setTimeout(() => {
                 loadingOverlay.classList.remove('active');
                 nationalizationOverlay.classList.add('active');
-            }, 3000);
+            }, 6000);
         }
 
         function saveDeliveryInfo() {


### PR DESCRIPTION
## Summary
- Amplía la espera del overlay de procesamiento de pago a seis segundos para simular un proceso más realista

## Testing
- `node --check pagos.js`


------
https://chatgpt.com/codex/tasks/task_e_68c27d2273bc832494efb23a53e478ad