### PR TITLE
fix: remove duplicate continue button update in shipping selection

### DIFF
--- a/pagos.js
+++ b/pagos.js
@@ -2721,7 +2721,6 @@
                 updateOrderSummary();
                 updateSelectionSummary();
                 updateContinueToPaymentBtnState();
-                updateContinueToPaymentBtnState();
 
                 const deliveryMessage = `Haz la compra hoy y recibe tu equipo el ${formatDate(estimatedDeliveryDate)}.`;
                 showToast('info', 'Envío seleccionado', `${option.querySelector('.shipping-title').textContent.trim()}. ${deliveryMessage}`);


### PR DESCRIPTION
## Summary
- remove duplicate call to updateContinueToPaymentBtnState in applyShippingSelection

## Testing
- `node --check pagos.js`
- `node test script verifying continue button enabled and function called once`


------
https://chatgpt.com/codex/tasks/task_e_68c2a94bdc0c8324bf4cc3c39a8c39be