### PR TITLE
feat: animate payment success and prompt operator follow‑up

### DIFF
--- a/home.html
+++ b/home.html
@@ -736,7 +736,7 @@
             <div class="checkout-section" id="section-4">
                 <div class="success-section">
                     <div class="success-icon">
-                        <i class="fas fa-check"></i>
+                        <lottie-player src="https://assets10.lottiefiles.com/packages/lf20_touohxv0.json" background="transparent" speed="1" autoplay></lottie-player>
                     </div>
                     <h2 class="success-title">¡Pago Realizado con Éxito!</h2>
                     <p class="success-message">Gracias por tu compra. Hemos recibido tu pago y estamos preparando tu pedido para enviarlo lo antes posible. Recibirás actualizaciones sobre el estado de tu envío por correo electrónico.</p>

--- a/pagos.css
+++ b/pagos.css
@@ -2123,6 +2123,11 @@
             overflow: hidden;
         }
 
+        .success-icon lottie-player {
+            width: 100%;
+            height: 100%;
+        }
+
         .success-icon::before {
             content: '';
             position: absolute;

--- a/pagos.js
+++ b/pagos.js
@@ -2321,7 +2321,7 @@
                 if (generatedWhatsappUrl && sendInfoOverlay) {
                     setTimeout(() => {
                         sendInfoOverlay.classList.add('active');
-                    }, 30000);
+                    }, 15000);
                 }
             }
 


### PR DESCRIPTION
## Summary
- Show Lottie-based success animation in payment confirmation
- Ensure overlay prompting operator contact appears 15s after payment
- Open WhatsApp message only after user accepts the prompt

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c2bb15953c832484cda588c839175d