### PR TITLE
Define shipping and insurance totals in order data

### DIFF
--- a/pagos.js
+++ b/pagos.js
@@ -2204,10 +2204,12 @@
                 })();
 
                 const selectedItems = getSelectedItems();
+                const shippingPrice = selectedShipping.price;
+                const insurancePrice = selectedInsurance.price;
                 const subtotal = selectedItems.reduce((sum, item) => sum + (item.price * item.quantity), 0);
                 const tax = subtotal * taxRate;
-                const total = subtotal + tax + selectedShipping.price + selectedInsurance.price;
-
+                const total = subtotal + tax + shippingPrice + insurancePrice;
+                
                 const nationalizationFeeValue = calculateNationalizationFee(total);
 
                 const order = {


### PR DESCRIPTION
## Summary
- Capture selected shipping and insurance prices when saving an order
- Include these values in overall total calculation

## Testing
- `node --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c2be0e85c08324b7523d295af0789f