### PR TITLE
Ensure payment success animation displays

### DIFF
--- a/pagos.js
+++ b/pagos.js
@@ -2161,6 +2161,7 @@
                 } finally {
                     setTimeout(() => {
                         loadingOverlay.classList.remove('active');
+                        continueAfterNationalization();
                     }, 6000);
                 }
         }


### PR DESCRIPTION
## Summary
- Call `continueAfterNationalization` after hiding loading overlay so checkout advances to success step.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c2c2bdf93483248e3bf39c0eeaa0cb