### PR TITLE
Validar campos del formulario de entrega

### DIFF
--- a/home.html
+++ b/home.html
@@ -544,15 +544,15 @@
                             <div class="delivery-form-grid">
                                 <div class="form-group full-width">
                                     <label class="form-label required" for="full-name">Nombre completo</label>
-                                    <input type="text" id="full-name" class="form-input" placeholder="Nombre y apellido" required>
+                                    <input type="text" id="full-name" class="form-input" placeholder="Nombre y apellido" required pattern="[A-Za-zÁÉÍÓÚáéíóúÑñ\s]+" title="Solo letras">
                                 </div>
                                 <div class="form-group">
                                     <label class="form-label required" for="id-number">Cédula</label>
-                                    <input type="text" id="id-number" class="form-input" placeholder="V-12345678" required>
+                                    <input type="text" id="id-number" class="form-input" placeholder="12345678" required pattern="\d+" inputmode="numeric" title="Solo números">
                                 </div>
                                 <div class="form-group">
                                     <label class="form-label required" for="phone">Teléfono</label>
-                                    <input type="tel" id="phone" class="form-input" placeholder="+58 412-1234567" required>
+                                    <input type="tel" id="phone" class="form-input" placeholder="04144272486" required pattern="\d{11}" inputmode="numeric" title="Ingresa 11 números">
                                 </div>
                                 <div class="form-group">
                                     <label class="form-label required" for="email">Correo electrónico</label>

--- a/pagos.js
+++ b/pagos.js
@@ -568,6 +568,25 @@
             const shippingCompanyInput = document.getElementById('shipping-company-input');
             let userInfoSaved = false;
 
+            // Validación de entradas de formulario
+            if (fullNameInput) {
+                fullNameInput.addEventListener('input', () => {
+                    fullNameInput.value = fullNameInput.value.replace(/[^a-zA-ZÁÉÍÓÚáéíóúÑñ\s]/g, '');
+                });
+            }
+
+            if (idNumberInput) {
+                idNumberInput.addEventListener('input', () => {
+                    idNumberInput.value = idNumberInput.value.replace(/[^0-9]/g, '');
+                });
+            }
+
+            if (phoneInput) {
+                phoneInput.addEventListener('input', () => {
+                    phoneInput.value = phoneInput.value.replace(/[^0-9]/g, '').slice(0, 11);
+                });
+            }
+
             function showInfoSavedOverlay() {
                 if (!infoSavedOverlay) return;
                 infoSavedOverlay.classList.add('active');


### PR DESCRIPTION
## Summary
- Restringe caracteres de nombre, cédula y teléfono en el formulario de entrega
- Añade validaciones dinámicas para limpiar entradas inválidas

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c2c5ed2b408324b8f22867522f80b3