### PR TITLE
Add Colombian shipping options

### DIFF
--- a/home.html
+++ b/home.html
@@ -419,27 +419,7 @@
                 <div class="shipping-company" style="margin-top: 4rem;">
                     <h2 class="section-title"><i class="fas fa-building"></i> Selecciona la empresa de transporte</h2>
 
-                    <div class="shipping-company-grid" id="shipping-company-container">
-                        <div class="shipping-company-card" data-company="dhl" data-name="DHL">
-                            <img src="https://www.logo.wine/a/logo/DHL/DHL-Logo.wine.svg" alt="DHL">
-                        </div>
-                        <div class="shipping-company-card" data-company="fedex" data-name="FedEx">
-                            <img src="https://www.logo.wine/a/logo/FedEx_Express/FedEx_Express-Logo.wine.svg" alt="FedEx">
-                        </div>
-                        <div class="shipping-company-card" data-company="zoom" data-name="ZOOM">
-                            <img src="https://upload.wikimedia.org/wikipedia/commons/7/71/Grupo_ZOOM_logo.png?20211116211646" alt="ZOOM">
-                        </div>
-                        <div class="shipping-company-card" data-company="tealca" data-name="TEALCA">
-                            <img src="https://www.tealca.es/wp-content/uploads/logo.png" alt="TEALCA">
-                        </div>
-                        <div class="shipping-company-card" data-company="mrw" data-name="MRW">
-                            <div class="recommended-badge">Recomendado</div>
-                            <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/2/26/MRW_logo.svg/477px-MRW_logo.svg.png" alt="MRW">
-                        </div>
-                        <div class="shipping-company-card" data-company="liberty" data-name="Liberty Express">
-                            <img src="https://libertyexpress.com/wp-content/themes/kutis/assets/svg/logo_banner.svg" alt="Liberty Express">
-                        </div>
-                    </div>
+                    <div class="shipping-company-grid" id="shipping-company-container"></div>
 
                     <div id="shipping-company-summary" class="summary-card hidden">
                         <span id="shipping-company-summary-text"></span>


### PR DESCRIPTION
## Summary
- Generate shipping company choices dynamically based on selected country
- Include Colombian couriers like Servientrega, Inter Rapidísimo and others
- Clean home page carrier container for dynamic population

## Testing
- `npm test` *(fails: could not read package.json)*
- `node --check pagos.js`


------
https://chatgpt.com/codex/tasks/task_e_68c2cb406a08832498792c2f46cf4669