### PR TITLE
Corregir selección de país para Colombia y Venezuela

### DIFF
--- a/pagos.js
+++ b/pagos.js
@@ -1352,6 +1352,15 @@
                 } else {
                     estadosCiudades = {};
                 }
+
+                // Actualizar listas de estados y ciudades según el país
+                populateStates();
+                if (locationStateSelect) {
+                    locationStateSelect.value = '';
+                }
+                if (locationCitySelect) {
+                    locationCitySelect.innerHTML = '<option value="">--Selecciona una ciudad--</option>';
+                }
                 
                 // Mostrar la sección de selección de producto (categorías)
                 stepCountry.style.display = 'none';


### PR DESCRIPTION
## Resumen
- Actualiza la lógica de selección de país para refrescar estados y ciudades al elegir Colombia o Venezuela.

## Testing
- `node --check pagos.js && echo "syntax ok"`


------
https://chatgpt.com/codex/tasks/task_e_68c2d8641b08832484cf7020c8d74011