### PR TITLE
Add store photos and Bogotá address to Nosotros section

### DIFF
--- a/index.html
+++ b/index.html
@@ -574,6 +574,21 @@
             margin-right: 10px;
         }
 
+        .store-gallery {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 20px;
+            justify-content: center;
+            margin-top: 30px;
+        }
+
+        .store-gallery img {
+            width: 100%;
+            max-width: 300px;
+            border-radius: var(--border-radius);
+            box-shadow: 0 10px 20px rgba(0, 0, 0, 0.1);
+        }
+
         footer {
             background-color: var(--primary-color);
             color: #fff;
@@ -2205,7 +2220,13 @@
                 <h3 style="margin-top: 30px;">Nuestras Ubicaciones</h3>
                 <div class="contact-info"><strong>Estados Unidos:</strong> Florida, Doral</div>
                 <div class="contact-info"><strong>Venezuela:</strong> Caracas, Torre Cavendes, Piso 8, Oficina L8-9C</div>
+                <div class="contact-info"><strong>Colombia:</strong> Calle 97 # 11-45, Barrio El Chicó, Bogotá, Colombia</div>
             </div>
+        </div>
+        <div class="store-gallery">
+            <img src="latinphonedoral.jpg" alt="Tienda LatinPhone Doral 1">
+            <img src="latinphonedoral2.jpg" alt="Tienda LatinPhone Doral 2">
+            <img src="latinphonedoral3.jpg" alt="Tienda LatinPhone Doral 3">
         </div>
     </section>
 


### PR DESCRIPTION
## Summary
- showcase LatinPhone store with new photo gallery
- list Bogotá, Colombia location in contact section
- style gallery for responsive layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c2db6408b48324851672bef1eb37a2