### PR TITLE
Handle Colombian currency and support

### DIFF
--- a/micuenta.html
+++ b/micuenta.html
@@ -352,7 +352,11 @@
     /** Utils **/
     const $ = (sel, root=document) => root.querySelector(sel);
     const $$ = (sel, root=document) => [...root.querySelectorAll(sel)];
-    const fmt = new Intl.NumberFormat('es-ES',{style:'currency',currency:'USD'});
+    const country = localStorage.getItem('lpCountry');
+    const currency = country === 'colombia' ? 'COP' : 'USD';
+    const locale = country === 'colombia' ? 'es-CO' : 'es-ES';
+    const rate = country === 'colombia' ? 4000 : 1;
+    const fmt = (val) => new Intl.NumberFormat(locale,{style:'currency',currency}).format(val * rate);
     const todayISO = () => new Date().toISOString().slice(0,10);
     const uid = (p='ID') => p + Math.random().toString(36).slice(2,9).toUpperCase();
 
@@ -506,7 +510,7 @@
                   <tr>
                     <td>${o.id}</td>
                     <td>${o.date}</td>
-                    <td>${fmt.format(o.total)}</td>
+                    <td>${fmt(o.total)}</td>
                     <td>${badgeStatus(o.status)}</td>
                     <td><button class="btn ghost" onclick="openOrder('${o.id}')">Detalles</button></td>
                   </tr>
@@ -548,7 +552,7 @@
                 <td>${o.id}</td>
                 <td>${o.date}</td>
                 <td>${o.items.reduce((a,b)=>a+b.qty,0)}</td>
-                <td>${fmt.format(o.total)}</td>
+                <td>${fmt(o.total)}</td>
                 <td>${badgeStatus(o.status)}</td>
                 <td>${o.shipping?.tracking||'-'}</td>
                 <td>
@@ -638,7 +642,7 @@
                 <td>${i.id}</td>
                 <td>${i.orderId}</td>
                 <td>${i.date}</td>
-                <td>${fmt.format(i.total)}</td>
+                <td>${fmt(i.total)}</td>
                 <td>${i.paid===false?'<span class="badge warn">Pendiente</span>':'<span class="badge success">Pagada</span>'}</td>
                 <td>
                   <div class="toolbar">
@@ -663,7 +667,7 @@
             <h3>Abrir un reclamo</h3>
             <form id="claimForm" class="grid">
               <select class="input" name="orderId" required>
-                ${getLS('lpOrders', []).map(o=> `<option value="${o.id}">${o.id} — ${o.date} (${fmt.format(o.total)})</option>`).join('')}
+                ${getLS('lpOrders', []).map(o=> `<option value="${o.id}">${o.id} — ${o.date} (${fmt(o.total)})</option>`).join('')}
               </select>
               <input class="input" name="subject" placeholder="Asunto del reclamo" required>
               <textarea class="input" name="message" placeholder="Describe el problema" rows="4" required></textarea>
@@ -991,8 +995,8 @@
                 <td>${it.name} <span class="muted">(${it.sku})</span></td>
                 <td>${it.color || '-'}</td>
                 <td>${it.qty}</td>
-                <td>${fmt.format(it.price)}</td>
-                <td>${fmt.format(it.price*it.qty)}</td>
+                <td>${fmt(it.price)}</td>
+                <td>${fmt(it.price*it.qty)}</td>
               </tr>
             `).join('')}
           </tbody>
@@ -1041,7 +1045,7 @@
           <div>
             <h4>Referencia</h4>
             <div>Pedido: <strong>${inv.orderId}</strong></div>
-            <div>Total: <strong>${fmt.format(inv.total)}</strong></div>
+            <div>Total: <strong>${fmt(inv.total)}</strong></div>
           </div>
         </div>
         <div class="hr"></div>
@@ -1049,8 +1053,8 @@
         <table class="table">
           <thead><tr><th>Concepto</th><th>Importe</th></tr></thead>
           <tbody>
-            ${order? order.items.map(it=>`<tr><td>${it.name}</td><td>${fmt.format(it.price*it.qty)}</td></tr>`).join('') : ''}
-            <tr><td><strong>Total</strong></td><td><strong>${fmt.format(inv.total)}</strong></td></tr>
+            ${order? order.items.map(it=>`<tr><td>${it.name}</td><td>${fmt(it.price*it.qty)}</td></tr>`).join('') : ''}
+            <tr><td><strong>Total</strong></td><td><strong>${fmt(inv.total)}</strong></td></tr>
           </tbody>
         </table>
         <div class="hr"></div>

--- a/mifactura.html
+++ b/mifactura.html
@@ -568,8 +568,8 @@
             <tr>
               <th>Descripción</th>
               <th class="right">Cant.</th>
-              <th class="right">Precio (USD)</th>
-              <th class="right">Importe (USD)</th>
+              <th class="right" id="priceHeader">Precio (USD)</th>
+              <th class="right" id="amountHeader">Importe (USD)</th>
             </tr>
           </thead>
           <tbody id="productsBody"></tbody>
@@ -578,9 +578,9 @@
 
         <div class="total-summary" aria-label="Resumen de totales">
           <div class="row"><span>Subtotal</span><b id="subtotalUSD"></b></div>
-          <div class="row"><span>IVA (16%)</span><b id="taxUSD"></b></div>
+          <div class="row"><span id="taxLabel">IVA (16%)</span><b id="taxUSD"></b></div>
           <div class="row"><span>Envío</span><b id="shippingUSD"></b></div>
-          <div class="row grand"><span>Total USD</span><span id="totalUSD"></span></div>
+          <div class="row grand"><span id="totalLabel">Total USD</span><span id="totalUSD"></span></div>
           <div class="row"><span class="badge" id="natLabel">Tasa de nacionalización</span><b id="natStatus" class="badge"></b></div>
           <div class="row" id="natPendingMsg" style="display:none;color:var(--danger);font-size:12px">Pendiente por pago. La compra podría ser anulada.</div>
         </div>
@@ -623,7 +623,7 @@
   <div id="alertOverlay" class="alert-overlay">
     <div class="alert-box">
       <div class="plane" aria-hidden="true">✈️</div>
-      <p>¡El equipo ya va vía Venezuela!</p>
+      <p>¡El equipo ya va en camino!</p>
       <p>La nacionalización fue pagada con éxito.</p>
       <button id="alertClose" class="alert-close">Cerrar</button>
     </div>
@@ -643,6 +643,12 @@
       mrw:{name:'MRW',logo:'https://upload.wikimedia.org/wikipedia/commons/2/26/MRW_logo.svg'},
       liberty:{name:'Liberty Express',logo:'https://libertyexpress.com/wp-content/themes/kutis/assets/svg/logo_banner.svg'}
     };
+
+    const country = localStorage.getItem('lpCountry');
+    const currency = country === 'colombia' ? 'COP' : 'USD';
+    const locale = country === 'colombia' ? 'es-CO' : 'es-ES';
+    const rate = country === 'colombia' ? 4000 : 1;
+    const fmt = (val) => new Intl.NumberFormat(locale,{style:'currency',currency}).format(val * rate);
 
     const orders = JSON.parse(localStorage.getItem('lpOrders')||'[]');
     if(!orders.length) return;
@@ -673,14 +679,19 @@
     const tbody = document.getElementById('productsBody');
     order.items.forEach(it=>{
       const tr = document.createElement('tr');
-      tr.innerHTML = `<td>${it.name} — <i>${it.color||''}</i></td><td class="right">${it.qty}</td><td class="right">$${it.price.toFixed(2)}</td><td class="right">$${(it.price*it.qty).toFixed(2)}</td>`;
+      tr.innerHTML = `<td>${it.name} — <i>${it.color||''}</i></td><td class="right">${it.qty}</td><td class="right">${fmt(it.price)}</td><td class="right">${fmt(it.price*it.qty)}</td>`;
       tbody.appendChild(tr);
     });
 
-    document.getElementById('subtotalUSD').textContent = `$${(totals.subtotal||0).toFixed(2)}`;
-    document.getElementById('taxUSD').textContent = `$${(totals.tax||0).toFixed(2)}`;
-    document.getElementById('shippingUSD').textContent = `$${(totals.shipping||0).toFixed(2)}`;
-    document.getElementById('totalUSD').textContent = `$${((totals.total!==undefined?totals.total:order.total)||0).toFixed(2)}`;
+    document.getElementById('subtotalUSD').textContent = fmt(totals.subtotal||0);
+    document.getElementById('taxUSD').textContent = fmt(totals.tax||0);
+    document.getElementById('shippingUSD').textContent = fmt(totals.shipping||0);
+    document.getElementById('totalUSD').textContent = fmt((totals.total!==undefined?totals.total:order.total)||0);
+
+    document.getElementById('priceHeader').textContent = `Precio (${currency})`;
+    document.getElementById('amountHeader').textContent = `Importe (${currency})`;
+    document.getElementById('totalLabel').textContent = `Total ${currency}`;
+    document.getElementById('taxLabel').textContent = country === 'colombia' ? 'IVA (19%)' : 'IVA (16%)';
 
     const natStatus = document.getElementById('natStatus');
     const natPendingMsg = document.getElementById('natPendingMsg');

--- a/miseguimiento.html
+++ b/miseguimiento.html
@@ -412,8 +412,10 @@ document.addEventListener('DOMContentLoaded', () => {
   };
 
   // ====== 3. UTILIDADES (Formateo de fechas) ======
-  const fmt = (iso) => new Intl.DateTimeFormat('es-VE', { dateStyle: 'short', timeStyle: 'short' }).format(new Date(iso));
-  const fmtDate = (iso) => new Intl.DateTimeFormat('es-VE', { dateStyle: 'long' }).format(new Date(iso));
+  const country = localStorage.getItem('lpCountry');
+  const locale = country === 'colombia' ? 'es-CO' : 'es-VE';
+  const fmt = (iso) => new Intl.DateTimeFormat(locale, { dateStyle: 'short', timeStyle: 'short' }).format(new Date(iso));
+  const fmtDate = (iso) => new Intl.DateTimeFormat(locale, { dateStyle: 'long' }).format(new Date(iso));
   
   const timeAgo = (date) => {
     const seconds = Math.floor((new Date() - date) / 1000);

--- a/na.html
+++ b/na.html
@@ -53,9 +53,6 @@
   .kv{display:flex;gap:10px;margin:8px 0}
   .kv b{min-width:170px;color:#566}
   .amount{font-size:22px;font-weight:800}
-  .copyrow{display:flex;gap:8px;align-items:center;margin:6px 0}
-  .pill{border:1px solid var(--line);border-radius:10px;padding:6px 10px;background:#fafafa}
-  button.copy{border:1px solid var(--line);background:#fff;border-radius:8px;padding:6px 10px;cursor:pointer}
   form{display:grid;gap:10px}
   label{font-size:13px;color:var(--muted)}
   input[type="text"], input[type="tel"], input[type="number"], input[type="date"], textarea, select{
@@ -155,24 +152,8 @@
         <!-- Instrucciones de Pago Móvil -->
         <section class="panel">
           <h3>Datos para Pago Móvil</h3>
-          <div class="kv"><b>Monto a cancelar</b> <span class="amount" id="amountBs"></span></div>
-          <div class="copyrow">
-            <div class="pill"><b>Teléfono receptor:</b> 0414-4272486</div>
-            <button class="copy" data-copy="04144272486">Copiar</button>
-          </div>
-          <div class="copyrow">
-            <div class="pill"><b>Cédula/RIF receptor:</b> 20.639.785</div>
-            <button class="copy" data-copy="20639785">Copiar</button>
-          </div>
-          <div class="copyrow">
-            <div class="pill"><b>Banco receptor:</b> Bancamiga</div>
-            <button class="copy" data-copy="Bancamiga">Copiar</button>
-          </div>
-          <div class="copyrow">
-            <div class="pill"><b>Concepto / Referencia:</b> <span id="conceptOrder"></span></div>
-            <button class="copy" id="copyConcept">Copiar</button>
-          </div>
-          <p class="help">Realiza el Pago Móvil por el monto exacto e introduce como <b>concepto</b> tu número de orden.</p>
+          <div class="kv"><b>Monto a cancelar</b> <span class="amount" id="amountLocal"></span></div>
+          <p class="help">Contacta a soporte para obtener los datos de Pago Móvil.</p>
 
           <h3 style="margin-top:14px">Seguimiento</h3>
           <div class="timeline" aria-label="Línea de tiempo">
@@ -199,7 +180,7 @@
                 <input id="formOrder" type="text" readonly>
               </div>
               <div>
-                <label>Monto (Bs)</label>
+                <label id="amountLabel">Monto (Bs)</label>
                 <input id="formAmount" type="text" readonly>
               </div>
             </div>
@@ -285,17 +266,19 @@
 
 <script>
   const user = JSON.parse(localStorage.getItem('lpUser') || '{}');
-  const fmtBs = new Intl.NumberFormat('es-VE',{style:'currency',currency:'VES'});
+  const country = localStorage.getItem('lpCountry') || 'venezuela';
+  const locale = country === 'colombia' ? 'es-CO' : 'es-VE';
+  const currency = pending && pending.currency ? pending.currency : (country === 'colombia' ? 'COP' : 'VES');
+  const fmt = new Intl.NumberFormat(locale,{style:'currency',currency});
   let orderId = pending ? pending.orderId : '';
-  let amountBs = pending ? parseFloat(pending.amountBs || '0') : 0;
+  let amount = pending ? parseFloat((pending.amount || pending.amountBs) || '0') : 0;
   if(pending){
     document.title = `Pago de Nacionalización — Orden ${orderId}`;
     document.getElementById('orderBadge').textContent = `Orden: ${orderId}`;
-    document.getElementById('amountBs').textContent = fmtBs.format(amountBs);
-    document.getElementById('conceptOrder').textContent = orderId;
-    document.getElementById('copyConcept').dataset.copy = orderId;
+    document.getElementById('amountLocal').textContent = fmt.format(amount);
     document.getElementById('formOrder').value = orderId;
-    document.getElementById('formAmount').value = fmtBs.format(amountBs).replace('Bs','').trim();
+    document.getElementById('formAmount').value = fmt.format(amount).replace(/[^0-9.,]/g,'').trim();
+    document.getElementById('amountLabel').textContent = `Monto (${currency})`;
     document.getElementById('purchaseDate').textContent = pending.date || '';
     if(pending.eta){
       const diffDays = Math.max(0, Math.ceil((new Date(pending.eta) - new Date())/86400000));
@@ -308,15 +291,6 @@
 
   // Prefija la fecha con hoy
   document.querySelector('input[name="fechaPago"]').valueAsDate = new Date();
-
-  // Copiar al portapapeles
-  document.querySelectorAll('button.copy').forEach(b=>{
-    b.addEventListener('click',()=>{
-      navigator.clipboard.writeText(b.dataset.copy||'');
-      b.textContent='Copiado ✓';
-      setTimeout(()=>b.textContent='Copiar',1200);
-    });
-  });
 
   // Drag & Drop para el comprobante
   const drop = document.getElementById('drop');
@@ -349,9 +323,9 @@
     const file = fileInput.files[0];
     const b64 = await toBase64(file);
 
-    const payload = {
+  const payload = {
       order: orderId,
-      amount_bs: fmtBs.format(amountBs).replace('Bs','').trim(),
+      amount: fmt.format(amount).replace(/[^0-9.,]/g,'').trim(),
       tel_pagador: form.telPagador.value.trim(),
       ci_pagador: form.cedulaPagador.value.trim(),
       banco_emisor: form.bancoEmisor.value.trim(),

--- a/pagos.js
+++ b/pagos.js
@@ -1341,6 +1341,7 @@
                 // Seleccionar el nuevo país
                 document.querySelector(`.country-card[data-country="${country}"]`).classList.add('selected');
                 selectedCountry = country;
+                localStorage.setItem('lpCountry', country);
                 populateShippingCompanies(country);
                 applyCountrySettings();
                 updateOrderSummary();
@@ -2445,7 +2446,8 @@
                 localStorage.setItem('lpOrders', JSON.stringify(orders));
                 localStorage.setItem('lpPendingNationalization', JSON.stringify({
                     orderId: orderNumber,
-                    amountBs: nationalizationFeeValue.toFixed(2),
+                    amount: nationalizationFeeValue.toFixed(2),
+                    currency: currencyLabel,
                     date: today,
                     eta: eta,
                     courier: selectedShippingCompany || '',


### PR DESCRIPTION
## Summary
- Hide Pago Móvil details and prompt users to contact support, while formatting fees in local currency
- Persist selected country and use it to format currency and labels across account, invoice, and tracking pages
- Apply locale-specific date formatting for Colombian users

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c2dc44777483249de97d44ef9b3dbc