### PR TITLE
Restrict checkout to supported countries

### DIFF
--- a/pagos.css
+++ b/pagos.css
@@ -542,6 +542,11 @@
             justify-content: center;
         }
 
+        .country-card:not([data-country="colombia"]):not([data-country="venezuela"]) {
+            cursor: not-allowed;
+            pointer-events: none;
+        }
+
         .country-card::before {
             content: '';
             position: absolute;

--- a/pagos.js
+++ b/pagos.js
@@ -1333,6 +1333,10 @@
 
             // Función para seleccionar un país
             function selectCountry(country) {
+                if (country !== 'colombia' && country !== 'venezuela') {
+                    return;
+                }
+
                 // Eliminar la selección actual
                 countryCards.forEach(card => {
                     card.classList.remove('selected');
@@ -2663,9 +2667,12 @@
             // Agregar eventos a los botones
             // 1. Selección de país
             countryCards.forEach(card => {
-                card.addEventListener('click', () => {
-                    selectCountry(card.getAttribute('data-country'));
-                });
+                const country = card.getAttribute('data-country');
+                if (country === 'colombia' || country === 'venezuela') {
+                    card.addEventListener('click', () => {
+                        selectCountry(country);
+                    });
+                }
             });
 
             // 2. Selección de categoría


### PR DESCRIPTION
## Summary
- Only attach country selection handler for Colombia and Venezuela
- Prevent unsupported country cards from receiving pointer events and show not-allowed cursor

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check pagos.js`


------
https://chatgpt.com/codex/tasks/task_e_68c2dee9a9f48324877b04a641de3aa2