### PR TITLE
Run pagos.js immediately using deferred loading

### DIFF
--- a/home.html
+++ b/home.html
@@ -53,6 +53,8 @@
     <!-- Confetti JS -->
     <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.6.0/dist/confetti.browser.min.js" defer></script>
     
+    <script src="pagos.js" defer></script>
+
 </head>
 <body>
     <nav class="top-bar">
@@ -1034,7 +1036,6 @@
     </div>
 
         <script src="account.js"></script>
-        <script src="pagos.js"></script>
         <script>
             document.addEventListener('DOMContentLoaded', () => {
                 if (window.sideCart) {

--- a/pagos.js
+++ b/pagos.js
@@ -1,5 +1,3 @@
-        // Inicializar el script cuando el DOM esté cargado
-        document.addEventListener('DOMContentLoaded', function() {
             const orderDateEl = document.getElementById('order-date');
             const paymentDateEl = document.getElementById('payment-date');
             const preparingDateRangeEl = document.getElementById('preparing-date-range');
@@ -3115,4 +3113,3 @@
 
             updateSelectionSummary();
             updateContinueToPaymentBtnState();
-        });


### PR DESCRIPTION
## Summary
- Remove DOMContentLoaded wrapper from `pagos.js` so script runs immediately
- Load `pagos.js` in `<head>` with `defer` to execute before DOMContentLoaded

## Testing
- `node --check pagos.js`
- `xmllint --html --noout home.html` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `npx -p jsdom node -e "const {JSDOM}=require('jsdom')"` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c30345a3b88324aaa3ca8ca0d1cac6