### PR TITLE
Enable country selection on checkout

### DIFF
--- a/home.html
+++ b/home.html
@@ -151,7 +151,7 @@
                         <div class="country-flag">🇨🇱</div>
                         <div class="country-name">Chile</div>
                     </div>
-                    <div class="country-card" data-country="colombia">
+                    <div class="country-card" data-country="colombia" onclick="selectCountry('colombia')">
                         <div class="country-flag">🇨🇴</div>
                         <div class="country-name">Colombia</div>
                     </div>
@@ -203,7 +203,7 @@
                         <div class="country-flag">🇺🇾</div>
                         <div class="country-name">Uruguay</div>
                     </div>
-                    <div class="country-card" data-country="venezuela">
+                    <div class="country-card" data-country="venezuela" onclick="selectCountry('venezuela')">
                         <div class="country-flag">🇻🇪</div>
                         <div class="country-name">Venezuela</div>
                     </div>

--- a/pagos.js
+++ b/pagos.js
@@ -1403,6 +1403,7 @@
 
                 autoAddPreselectedProduct();
             }
+            window.selectCountry = selectCountry;
 
             // Función para seleccionar una categoría
             function selectCategory(category) {


### PR DESCRIPTION
## Summary
- expose `selectCountry` function globally
- bind country card clicks for Colombia and Venezuela to trigger selection

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c30907be44832483fedbc95a3bea86