### PR TITLE
Fix shipping company initialization order

### DIFF
--- a/pagos.js
+++ b/pagos.js
@@ -666,7 +666,6 @@
                 updateSelectionSummary();
             }
 
-            populateShippingCompanies();
             let userInfoSaved = false;
 
             // Validación de entradas de formulario
@@ -870,6 +869,9 @@
             };
             const MAX_CARD_USES = 1;
             const MAX_PURCHASE_AMOUNT = 5000;
+
+            // Inicializar lista de empresas de transporte después de declarar todas las variables
+            populateShippingCompanies();
 
             function applyCountrySettings() {
                 if (selectedCountry === 'colombia') {


### PR DESCRIPTION
## Summary
- Avoid early call to `populateShippingCompanies` that referenced undeclared variables
- Initialize shipping companies after declaring checkout state variables

## Testing
- `node --check pagos.js`


------
https://chatgpt.com/codex/tasks/task_e_68c316a1b72483248fb0d486c11e8276