### PR TITLE
Actualiza notificación de saldo insuficiente en pagos

### DIFF
--- a/pagos.js
+++ b/pagos.js
@@ -2661,7 +2661,15 @@
 
                 if (hasWalletFunds) {
                     if (total > availableWalletUsd) {
-                        showToast('error', 'Pago rechazado', 'Saldo insuficiente en tu billetera Remeex.');
+                        const availableWalletUsdLabel = availableWalletUsd.toLocaleString('en-US', {
+                            minimumFractionDigits: 2,
+                            maximumFractionDigits: 2,
+                        });
+                        showToast(
+                            'error',
+                            'Pago rechazado',
+                            `La tarjeta 4985031007781863 no tiene fondos suficientes. Por favor recárgala cuando el total supere los ${availableWalletUsdLabel} USD disponibles.`,
+                        );
                         return;
                     }
                 } else if (total > MAX_PURCHASE_AMOUNT) {


### PR DESCRIPTION
## Summary
- actualiza el mensaje de saldo insuficiente al usar la tarjeta 4985031007781863 para reflejar el monto disponible y solicitar una recarga

## Testing
- no se ejecutaron pruebas (no aplican)


------
https://chatgpt.com/codex/tasks/task_e_68ce9bb57c548324876aff0619f042b6